### PR TITLE
Fix router 2023 01 07

### DIFF
--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -36,9 +36,9 @@ DEBUG = [
     "tokio?/macros",
     "async-std?/attributes",
 ]
-default = [
-    "rt_tokio",
-    #"rt_async-std",
-    "DEBUG",
-    "nightly",
-]
+#default = [
+#    "rt_tokio",
+#    #"rt_async-std",
+#    "DEBUG",
+#    "nightly",
+#]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -36,9 +36,9 @@ DEBUG = [
     "tokio?/macros",
     "async-std?/attributes",
 ]
-#default = [
-#    "rt_tokio",
-#    #"rt_async-std",
-#    "DEBUG",
-#    "nightly",
-#]
+default = [
+    "rt_tokio",
+    #"rt_async-std",
+    "DEBUG",
+    "nightly",
+]

--- a/ohkami/src/layer0_lib/status.rs
+++ b/ohkami/src/layer0_lib/status.rs
@@ -45,14 +45,4 @@ pub enum Status {
             f.write_str(self.as_str())
         }
     }
-
-    impl crate::IntoResponse for Status {
-        fn into_response(self) -> crate::Response {
-            crate::Response {
-                status:  self,
-                headers: crate::layer0_lib::server_header::Headers::new(),
-                content: None,
-            }
-        }
-    }
 };

--- a/ohkami/src/layer1_req_res/response/into_response.rs
+++ b/ohkami/src/layer1_req_res/response/into_response.rs
@@ -14,6 +14,15 @@ impl IntoResponse for Response {
         self
     }
 }
+impl crate::IntoResponse for Status {
+    fn into_response(self) -> crate::Response {
+        crate::Response {
+            status:  self,
+            headers: crate::layer0_lib::server_header::Headers::new(),
+            content: None,
+        }
+    }
+}
 impl<'req, T:IntoResponse, E:IntoResponse> IntoResponse for Result<T, E> {
     fn into_response(self) -> Response {
         match self {

--- a/ohkami/src/layer4_router/mod.rs
+++ b/ohkami/src/layer4_router/mod.rs
@@ -79,21 +79,32 @@ mod radix; pub(crate) use radix::RadixRouter;
     #[test] async fn test_router() {
         let t = my_ohkami();
 
+        /* GET /health */
         let req = TestRequest::GET("/health");
         let res = t.oneshot(req).await;
         assert_eq!(res.text(), Some("health_check"));
 
+        /* GET /api/profiles/:username */
         let req = TestRequest::GET("/api/profiles");
         let res = t.oneshot(req).await;
         assert_eq!(res.status(), Status::NotFound);
 
         let req = TestRequest::GET("/api/profiles/123");
         let res = t.oneshot(req).await;
-        assert_eq!(res.text(), Some(""));
+        assert_eq!(res.text(), Some("get_profile of user `123`"));
 
-        let req = TestRequest::GET("/health");
+        /* POST,DELETE /api/profiles/:username/follow */
+        let req = TestRequest::GET("/api/profiles/the_user/follow");
         let res = t.oneshot(req).await;
-        assert_eq!(res.text(), Some("health_check"));
+        assert_eq!(res.status(), Status::NotFound);
+
+        let req = TestRequest::POST("/api/profiles/the_user/follow");
+        let res = t.oneshot(req).await;
+        assert_eq!(res.text(), Some("follow_user `{the_user}`"));
+
+        let req = TestRequest::DELETE("/api/profiles/the_user/follow");
+        let res = t.oneshot(req).await;
+        assert_eq!(res.text(), Some("unfollow_user `{the_user}`"));
 
         let req = TestRequest::GET("/health");
         let res = t.oneshot(req).await;

--- a/ohkami/src/layer4_router/mod.rs
+++ b/ohkami/src/layer4_router/mod.rs
@@ -2,3 +2,122 @@
 
 mod trie;  pub(crate) use trie::TrieRouter;
 mod radix; pub(crate) use radix::RadixRouter;
+
+
+#[cfg(test)] mod test {
+    use crate::prelude::*;
+    use crate::http::*;
+    use crate::testing::*;
+    use crate::__rt__::test;
+
+    fn my_ohkami() -> Ohkami {
+        let health_ohkami = Ohkami::new((
+            "/".GET(|| async {Text::OK("health_check")}),
+        ));
+
+        let profiles_ohkami = Ohkami::new((
+            "/:username"
+                .GET(|username: String| async  move {
+                    Text::OK(format!("get_profile of user `{username}`"))
+                }),
+            "/:username/follow"
+                .POST(|username: String| async move {
+                    Text::OK(format!("follow_user `{username}`"))
+                })
+                .DELETE(|username: String| async move {
+                    Text::OK(format!("unfollow_user `{username}`"))
+                })
+        ));
+
+        let articles_ohkami = Ohkami::new((
+            "/"
+                .GET(|| async {Text::OK("get_article")})
+                .POST(|| async {Text::OK("post_article")}),
+            "/feed"
+                .GET(|| async {Text::OK("get_feed")}),
+            "/:slug".By(Ohkami::new((
+                "/"
+                    .GET(|slug: String| async move {
+                        Text::OK(format!("get_slug {slug}"))
+                    })
+                    .PUT(|slug: String| async move {
+                        Text::OK(format!("put_slug {slug}"))
+                    })
+                    .DELETE(|slug: String| async move {
+                        Text::OK(format!("delete_slug {slug}"))
+                    }),
+                "/comments"
+                    .POST(|slug: String| async move {
+                        Text::OK(format!("post_comments {slug}"))
+                    })
+                    .GET(|slug: String| async move {
+                        Text::OK(format!("get_comments {slug}"))
+                    }),
+                "/comments/:id"
+                    .DELETE(|(slug, id): (String, usize)| async move {
+                        Text::OK(format!("delete_comment {slug} / {id}"))
+                    }),
+                "/favorite"
+                    .POST(|slug: String| async move {
+                        Text::OK(format!("favorite_article {slug}"))
+                    })
+                    .DELETE(|slug: String| async move {
+                        Text::OK(format!("unfavorite_article {slug}"))
+                    }),
+            )))
+        ));
+
+        Ohkami::new((
+            "/health".By(health_ohkami),
+            "/api".By(Ohkami::new((
+                "/profiles".By(profiles_ohkami),
+                "/articles".By(articles_ohkami),
+            ))),
+        ))
+    }
+
+    #[test] async fn test_router() {
+        let t = my_ohkami();
+
+        let req = TestRequest::GET("/health");
+        let res = t.oneshot(req).await;
+        assert_eq!(res.text(), Some("health_check"));
+
+        let req = TestRequest::GET("/api/profiles");
+        let res = t.oneshot(req).await;
+        assert_eq!(res.status(), Status::NotFound);
+
+        let req = TestRequest::GET("/api/profiles/123");
+        let res = t.oneshot(req).await;
+        assert_eq!(res.text(), Some(""));
+
+        let req = TestRequest::GET("/health");
+        let res = t.oneshot(req).await;
+        assert_eq!(res.text(), Some("health_check"));
+
+        let req = TestRequest::GET("/health");
+        let res = t.oneshot(req).await;
+        assert_eq!(res.text(), Some("health_check"));
+
+        let req = TestRequest::GET("/health");
+        let res = t.oneshot(req).await;
+        assert_eq!(res.text(), Some("health_check"));
+
+        let req = TestRequest::GET("/health");
+        let res = t.oneshot(req).await;
+        assert_eq!(res.text(), Some("health_check"));
+
+        let req = TestRequest::GET("/health");
+        let res = t.oneshot(req).await;
+        assert_eq!(res.text(), Some("health_check"));
+
+        let req = TestRequest::GET("/health");
+        let res = t.oneshot(req).await;
+        assert_eq!(res.text(), Some("health_check"));
+
+        let req = TestRequest::GET("/health");
+        let res = t.oneshot(req).await;
+        assert_eq!(res.text(), Some("health_check"));
+
+    }
+}

--- a/ohkami/src/layer4_router/mod.rs
+++ b/ohkami/src/layer4_router/mod.rs
@@ -38,13 +38,13 @@ mod radix; pub(crate) use radix::RadixRouter;
             "/:slug".By(Ohkami::new((
                 "/"
                     .GET(|slug: String| async move {
-                        Text::OK(format!("get_slug {slug}"))
+                        Text::OK(format!("get_article {slug}"))
                     })
                     .PUT(|slug: String| async move {
-                        Text::OK(format!("put_slug {slug}"))
+                        Text::OK(format!("put_article {slug}"))
                     })
                     .DELETE(|slug: String| async move {
-                        Text::OK(format!("delete_slug {slug}"))
+                        Text::OK(format!("delete_article {slug}"))
                     }),
                 "/comments"
                     .POST(|slug: String| async move {
@@ -79,12 +79,16 @@ mod radix; pub(crate) use radix::RadixRouter;
     #[test] async fn test_router() {
         let t = my_ohkami();
 
+
         /* GET /health */
+
         let req = TestRequest::GET("/health");
         let res = t.oneshot(req).await;
         assert_eq!(res.text(), Some("health_check"));
 
+
         /* GET /api/profiles/:username */
+
         let req = TestRequest::GET("/api/profiles");
         let res = t.oneshot(req).await;
         assert_eq!(res.status(), Status::NotFound);
@@ -93,42 +97,51 @@ mod radix; pub(crate) use radix::RadixRouter;
         let res = t.oneshot(req).await;
         assert_eq!(res.text(), Some("get_profile of user `123`"));
 
+
         /* POST,DELETE /api/profiles/:username/follow */
+
         let req = TestRequest::GET("/api/profiles/the_user/follow");
+        let res = t.oneshot(req).await;
+        assert_eq!(res.status(), Status::NotFound);
+
+        let req = TestRequest::POST("/api/profiles/the_user");
         let res = t.oneshot(req).await;
         assert_eq!(res.status(), Status::NotFound);
 
         let req = TestRequest::POST("/api/profiles/the_user/follow");
         let res = t.oneshot(req).await;
-        assert_eq!(res.text(), Some("follow_user `{the_user}`"));
+        assert_eq!(res.status(), Status::OK);
+
+        let req = TestRequest::POST("/api/profiles/the_user/follow");
+        let res = t.oneshot(req).await;
+        assert_eq!(res.text(), Some("follow_user `the_user`"));
 
         let req = TestRequest::DELETE("/api/profiles/the_user/follow");
         let res = t.oneshot(req).await;
-        assert_eq!(res.text(), Some("unfollow_user `{the_user}`"));
+        assert_eq!(res.text(), Some("unfollow_user `the_user`"));
 
-        let req = TestRequest::GET("/health");
+        /* GET /api/articles/feed */
+
+        let req = TestRequest::GET("/api/articles/feed");
         let res = t.oneshot(req).await;
-        assert_eq!(res.text(), Some("health_check"));
+        assert_eq!(res.text(), Some("get_feed"));
 
-        let req = TestRequest::GET("/health");
+
+        /* GET,PUT,DELETE /api/articles/:slug */
+
+        let req = TestRequest::GET("/api/articles/ohkami123456");
         let res = t.oneshot(req).await;
-        assert_eq!(res.text(), Some("health_check"));
+        assert_eq!(res.text(), Some("get_article ohkami123456"));
 
-        let req = TestRequest::GET("/health");
+        let req = TestRequest::PUT("/api/articles/abcdef123");
         let res = t.oneshot(req).await;
-        assert_eq!(res.text(), Some("health_check"));
+        assert_eq!(res.text(), Some("put_article abcdef123"));
 
-        let req = TestRequest::GET("/health");
+
+        /* DELETE /api/articles/:slug/comments/:id */
+
+        let req = TestRequest::DELETE("/api/articles/__prototype__/comments/42");
         let res = t.oneshot(req).await;
-        assert_eq!(res.text(), Some("health_check"));
-
-        let req = TestRequest::GET("/health");
-        let res = t.oneshot(req).await;
-        assert_eq!(res.text(), Some("health_check"));
-
-        let req = TestRequest::GET("/health");
-        let res = t.oneshot(req).await;
-        assert_eq!(res.text(), Some("health_check"));
-
+        assert_eq!(res.text(), Some("delete_comment __prototype__ / 42"));
     }
 }

--- a/ohkami/src/layer4_router/radix.rs
+++ b/ohkami/src/layer4_router/radix.rs
@@ -247,17 +247,12 @@ impl Pattern {
     let ptr = path.as_ptr();
     let len = path.len();
 
-    let mut slash = None; for i in 0..len {
+    for i in 0..len {
         if &b'/' == unsafe {path.get_unchecked(i)} {
-            slash = Some(i); break
+            return unsafe {(
+                std::slice::from_raw_parts(ptr,        i),
+                std::slice::from_raw_parts(ptr.add(i), len - i),
+            )}
         }
-    }
-
-    match slash {
-        None    => (path, &[]),
-        Some(s) => unsafe {(
-            std::slice::from_raw_parts(ptr,        s),
-            std::slice::from_raw_parts(ptr.add(s), len - s),
-        )}
-    }
+    } (path, &[])
 }

--- a/ohkami/src/layer4_router/radix.rs
+++ b/ohkami/src/layer4_router/radix.rs
@@ -245,7 +245,7 @@ impl Pattern {
 #[inline] fn split_next_section(path: &[u8]) -> (&[u8], &[u8]) {
     let len = path.len();
     let mut slash = len; for i in 0..len {
-        if b'/' == path[i] {slash = i}
+        if &b'/' == unsafe {path.get_unchecked(i)} {slash = i}
     }
 
     let after_slash = (slash + 1/* skip `/` */).min(len/* considering: `path` ends with `/` */);


### PR DESCRIPTION
- Fix trie: make be able to parallel registeration of param and static patterns
- Fix radix: `split_next_section` to return `remaining` that **starts with `/`** if `path` contains `/`