### PR TITLE
Fix: curl path in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ async fn main() {
 $ cargo run
 ```
 ```sh
-$ curl http://localhost:3000/hc
+$ curl http://localhost:3000/healthz
 $ curl http://localhost:3000/hello/your_name
 Hello, your_name!
 ```


### PR DESCRIPTION
Fix:

```diff
- $ curl http://localhost:3000/hc
+ $ curl http://localhost:3000/healthz
  $ curl http://localhost:3000/hello/your_name
  Hello, your_name!
```
