### PR TITLE
Fix: `Request::path(&self)`: show `/` to user if internal path bytes is `` (empty)

### DIFF
--- a/ohkami/src/layer1_req_res/request/mod.rs
+++ b/ohkami/src/layer1_req_res/request/mod.rs
@@ -232,18 +232,18 @@ impl Request {
     }
 
     /// Memorize any data within this request object
-    pub fn memorize<Value: Send + Sync + 'static>(&mut self, value: Value) {
+    #[inline(always)] pub fn memorize<Value: Send + Sync + 'static>(&mut self, value: Value) {
         self.store.insert(value)
     }
     /// Retrieve a data memorized in this request (using the type as key)
-    pub fn memorized<Value: Send + Sync + 'static>(&self) -> Option<&Value> {
+    #[inline(always)] pub fn memorized<Value: Send + Sync + 'static>(&self) -> Option<&Value> {
         self.store.get()
     }
 }
 
 impl Request {
-    #[inline(always)] pub(crate) unsafe fn path_bytes<'b>(&self) -> &'b [u8] {
-        self.path.as_bytes()
+    #[inline(always)] pub(crate) unsafe fn internal_path_bytes<'b>(&self) -> &'b [u8] {
+        self.path.as_internal_bytes()
     }
 }
 

--- a/ohkami/src/layer1_req_res/request/path.rs
+++ b/ohkami/src/layer1_req_res/request/path.rs
@@ -29,7 +29,7 @@ impl Path {
             returns `b"/"` if that bytes is `b"/"`.
         */
         let mut len = bytes.len();
-        if bytes[len-1] == b'/' {len-=1};
+        if *bytes.get_unchecked(len-1) == b'/' {len-=1};
 
         Self {
             raw:    Slice::new(bytes.as_ptr(), len),

--- a/ohkami/src/layer1_req_res/request/path.rs
+++ b/ohkami/src/layer1_req_res/request/path.rs
@@ -19,6 +19,15 @@ impl Path {
             bytes.starts_with(b"/")
         }
 
+        /*
+            Strip trailing '/' **even when `bytes` is just `b"/"`**
+            (then the bytes become b"" (empty bytes)).
+
+            This suits to ohkami's radix router's searching algorithm and,
+            while `Path::as_internal_bytes` directly returns the result bytes,
+            `Path::as_bytes`, intended to be used by `Request::{pub fn path(&self)}`,
+            returns `b"/"` if that bytes is `b"/"`.
+        */
         let mut len = bytes.len();
         if bytes[len-1] == b'/' {len-=1};
 
@@ -38,8 +47,14 @@ impl Path {
         )
     }
 
-    #[inline] pub(crate) unsafe fn as_bytes<'req>(&self) -> &'req [u8] {
+    #[inline] pub(crate) unsafe fn as_internal_bytes<'req>(&self) -> &'req [u8] {
         self.raw.as_bytes()
+    }
+    #[inline] pub(crate) unsafe fn as_bytes<'req>(&self) -> &'req [u8] {
+        match self.raw.as_bytes() {
+            b""  => b"/",
+            some => some,
+        }
     }
 }
 

--- a/ohkami/src/layer3_router/radix.rs
+++ b/ohkami/src/layer3_router/radix.rs
@@ -198,14 +198,14 @@ impl Node {
         // 2. `Request` DOESN'T have method that mutates `path`,
         //    So what `path` refers to is NEVER changed by any other process
         //    while `search`
-        let path_bytes_maybe_percent_encoded = unsafe {req.path_bytes()};
+        let path_bytes_maybe_percent_encoded = unsafe {req.internal_path_bytes()};
         // Decode percent encodings in `path_bytes_maybe_percent_encoded`,
         // without checking entire it is valid UTF-8.
         let decoded = percent_decode(path_bytes_maybe_percent_encoded);
         let mut path: &[u8] = &decoded;
 
         #[cfg(feature="DEBUG")]
-        println!("[path] {}", path.escape_ascii());
+        println!("[path] '{}'", path.escape_ascii());
 
         loop {
             for ff in target.front {
@@ -225,7 +225,7 @@ impl Node {
                 path = unsafe {path.get_unchecked(1..)};
                 
                 #[cfg(feature="DEBUG")]
-                println!("[path stripped '/'] {}", path.escape_ascii());
+                println!("[path - prefix '/'] '{}'", path.escape_ascii());
         
                 match pattern {
                     Pattern::Static(s)  => path = match path.strip_prefix(*s) {


### PR DESCRIPTION
- Add a comment describing why it's ok to force-strip trailing `/` in request path even if raw path was just `/`
- Fix: `Request::path(&self)` to show user `/` if internal path bytes is `` (empty, e.t. the original request path was `/`)