### PR TITLE
Fix around request handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ async fn main() {
             .GET(health_check),
         "/hello/:name"
             .GET(hello),
-    )).howl(3000).await
+    )).howl("localhost:3000").await
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 - *multi runtime* support：`tokio`, `async-std`
 
 <div align="right">
-    <img alt="build check status of ohkami" src="https://github.com/kana-rus/ohkami/actions/workflows/CI.yml/badge.svg"/>
+    <a href="https://github.com/kana-rus/ohkami/actions"><img alt="build check status of ohkami" src="https://github.com/kana-rus/ohkami/actions/workflows/CI.yml/badge.svg"/></a>
+    <a href="https://crates.io/crates/ohkami"><img alt="crates.io" src="https://img.shields.io/crates/v/ohkami" /></a>
+    <a href="https://github.com/kana-rus/ohkami/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/crates/l/ohkami.svg" /></a>
 </div>
 
 <br>
@@ -239,8 +241,17 @@ async fn test_my_ohkami() {
 
 <br>
 
+## Supporting protocol
+- [x] HTTP/1.1
+- [ ] HTTPS
+- [ ] HTTP/2
+- [ ] HTTP/3
+- [ ] WebSocket
+
+<br>
+
 ## MSRV (Minimum Supported Rust Version)
 Latest stable.
 
 ## License
-`ohkami` is licensed under MIT LICENSE ([LICENSE-MIT](https://github.com/kana-rus/ohkami/blob/main/LICENSE-MIT) or [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)).
+`ohkami` is licensed under MIT LICENSE ([LICENSE](https://github.com/kana-rus/ohkami/blob/main/LICENSE) or [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)).

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ impl IntoFang for LogRequest {
 async fn main() {
     Ohkami::with((AppendHeaders, LogRequest), (
         "/".GET(|| async {"Hello!"})
-    )).howl(":8080").await
+    )).howl("localhost:8080").await
 }
 
 ```
@@ -204,7 +204,7 @@ async fn main() {
     Ohkami::new((
         "/healthz"  .GET(health_check),
         "/api/users".By(users_ohkami), // <-- nest by `By`
-    )).howl(5000).await
+    )).howl("localhost:5000").await
 }
 ```
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,9 +8,10 @@ members  = [
 ]
 
 [workspace.dependencies]
-ohkami             = { version = "0.13.0", path = "../ohkami", features = ["rt_tokio"] }
+# To assure "DEBUG" feature be off even if DEBUGing `../ohkami`,
+# explicitly set `default-features = false`
+ohkami             = { version = "0.13.0", path = "../ohkami", default-features = false, features = ["rt_tokio", "utils", "testing"] }
 tokio              = { version = "1", features = ["full"] }
-serde              = { version = "1", features = ["derive"] }
 sqlx               = { version = "0.7.3", features = ["runtime-tokio-native-tls", "postgres", "macros", "chrono", "uuid"] }
 tracing            = "0.1"
 tracing-subscriber = "0.3"

--- a/examples/form/Cargo.toml
+++ b/examples/form/Cargo.toml
@@ -6,6 +6,5 @@ edition            = "2021"
 [dependencies]
 ohkami             = { workspace = true }
 tokio              = { workspace = true }
-serde              = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -47,5 +47,5 @@ async fn main() {
     Ohkami::with(Logger, (
         "/form"  .GET(get_form),
         "/submit".POST(post_submit),
-    )).howl(5000).await
+    )).howl("localhost:5000").await
 }

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -6,6 +6,5 @@ edition            = "2021"
 [dependencies]
 ohkami             = { workspace = true }
 tokio              = { workspace = true }
-serde              = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -28,8 +28,7 @@ mod hello_handler {
     }
 
 
-    #[Payload(JSON)]
-    #[derive(serde::Deserialize)]
+    #[Payload(JSOND)]
     pub struct HelloRequest<'n> {
         name:   &'n str,
         repeat: Option<usize>,
@@ -120,5 +119,5 @@ async fn main() {
     Ohkami::with(LogRequest, (
         "/hc" .GET(health_handler::health_check),
         "/api".By(hello_ohkami),
-    )).howl(3000).await
+    )).howl("localhost:3000").await
 }

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -107,7 +107,7 @@ async fn main() {
         .with_max_level(tracing::Level::INFO)
         .init();
 
-    let hello_ohkami = Ohkami::with((SetServer, LogRequest), (
+    let hello_ohkami = Ohkami::with((SetServer,), (
         "/query".
             GET(hello_handler::hello_by_query),
         "/json".
@@ -116,7 +116,7 @@ async fn main() {
 
     tracing::info!("Started listening on http://localhost:3000");
 
-    Ohkami::with(LogRequest, (
+    Ohkami::with((LogRequest, LogRequest), (
         "/hc" .GET(health_handler::health_check),
         "/api".By(hello_ohkami),
     )).howl("localhost:3000").await

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -72,9 +72,9 @@ mod fangs {
                     .Server("ohkami");
 
                 tracing::info!("\
-                    Called `append_server`\n\
+                    Called `SetServer`\n\
                     [current headers]\n\
-                    {:?}\
+                    {:?}\n\
                 ", res.headers);
             })
         }
@@ -87,7 +87,7 @@ mod fangs {
                 let __method__ = req.method();
                 let __path__   = req.path();
 
-                tracing::info!("\
+                tracing::info!("\n\
                     Got request:\n\
                     [ method ] {__method__}\n\
                     [  path  ] {__path__}\n\

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -107,7 +107,7 @@ async fn main() {
         .with_max_level(tracing::Level::INFO)
         .init();
 
-    let hello_ohkami = Ohkami::with((SetServer,), (
+    let hello_ohkami = Ohkami::with((SetServer, LogRequest), (
         "/query".
             GET(hello_handler::hello_by_query),
         "/json".
@@ -116,7 +116,7 @@ async fn main() {
 
     tracing::info!("Started listening on http://localhost:3000");
 
-    Ohkami::with((LogRequest, LogRequest), (
+    Ohkami::with((LogRequest,), (
         "/hc" .GET(health_handler::health_check),
         "/api".By(hello_ohkami),
     )).howl("localhost:3000").await

--- a/examples/quick_start/src/main.rs
+++ b/examples/quick_start/src/main.rs
@@ -16,5 +16,5 @@ async fn main() {
             GET(health_check),
         "/hello/:name".
             GET(hello),
-    )).howl(3000).await
+    )).howl("localhost:3000").await
 }

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -29,7 +29,7 @@ hmac          = { version = "=0.13.0-pre.0", default-features = false }
 rustc-hash    = { version = "1.1", optional = true }
 
 [features]
-default       = ["utils", "testing"]
+#default       = ["utils", "testing"]
 rt_tokio      = ["dep:tokio"]
 rt_async-std  = ["dep:async-std"]
 utils         = []
@@ -44,12 +44,12 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-#default = [
-#    "utils",
-#    "testing",
-#    "custom-header",
-#    #"websocket",
-#    "rt_tokio",
-#    #"rt_async-std",
-#    "DEBUG",
-#]
+default = [
+    "utils",
+    "testing",
+    "custom-header",
+    #"websocket",
+    "rt_tokio",
+    #"rt_async-std",
+    "DEBUG",
+]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -22,14 +22,14 @@ tokio         = { version = "1", optional = true, features = ["net", "rt", "io-u
 async-std     = { version = "1", optional = true }
 byte_reader   = { version = "2.0.0", features = ["text"] }
 serde         = { version = "1.0",   features = ["derive"] }
-serde_json    = "1.0"
+serde_json    = { version = "1.0" }
 sha1          = { version = "=0.11.0-pre.0", optional = true, default-features = false }
 sha2          = { version = "=0.11.0-pre.0", default-features = false }
 hmac          = { version = "=0.13.0-pre.0", default-features = false }
 rustc-hash    = { version = "1.1", optional = true }
 
 [features]
-#default       = ["utils", "testing"]
+default       = ["utils", "testing"]
 rt_tokio      = ["dep:tokio"]
 rt_async-std  = ["dep:async-std"]
 utils         = []
@@ -44,12 +44,12 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-default = [
-    "utils",
-    "testing",
-    "custom-header",
-    #"websocket",
-    "rt_tokio",
-    #"rt_async-std",
-    "DEBUG",
-]
+#default = [
+#    "utils",
+#    "testing",
+#    "custom-header",
+#    #"websocket",
+#    "rt_tokio",
+#    #"rt_async-std",
+#    "DEBUG",
+#]

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -24,7 +24,7 @@ use crate::{IntoFang, Fang, Response, Request, append, Status, Method};
 ///         "/api".GET(|| async {
 ///             "Hello, CORS!"
 ///         }),
-///     )).howl(8080).await
+///     )).howl("localhost:8080").await
 /// }
 /// ```
 pub struct CORS {

--- a/ohkami/src/fang/builtin/jwt.rs
+++ b/ohkami/src/fang/builtin/jwt.rs
@@ -327,8 +327,7 @@ impl JWT {
         use crate::{testing::*, Memory};
         use crate::typed::{ResponseBody, status::OK};
 
-        use std::{sync::OnceLock, collections::HashMap, borrow::Cow};
-        use crate::__rt__::Mutex;
+        use std::{sync::OnceLock, sync::Mutex, collections::HashMap, borrow::Cow};
 
 
         fn my_jwt() -> JWT {
@@ -399,7 +398,7 @@ impl JWT {
         }
 
         async fn get_profile(jwt_payload: Memory<'_, MyJWTPayload>) -> Result<OK<Profile>, APIError> {
-            let r = &mut *repository().await.lock().await;
+            let r = &mut *repository().await.lock().unwrap();
 
             let user = r.get(&jwt_payload.user_id)
                 .ok_or_else(|| APIError::UserNotFound)?;
@@ -421,7 +420,7 @@ impl JWT {
         }
 
         async fn signin(body: SigninRequest<'_>) -> utils::Text {
-            let r = &mut *repository().await.lock().await;
+            let r = &mut *repository().await.lock().unwrap();
 
             let user: Cow<'_, User> = match r.iter().find(|(_, u)|
                 u.first_name   == body.first_name &&
@@ -510,7 +509,7 @@ impl JWT {
 
 
         assert_eq! {
-            &*repository().await.lock().await,
+            &*repository().await.lock().unwrap(),
             &HashMap::from([
                 (1, User {
                     id:           1,
@@ -542,7 +541,7 @@ impl JWT {
 
 
         assert_eq! {
-            &*repository().await.lock().await,
+            &*repository().await.lock().unwrap(),
             &HashMap::from([
                 (1, User {
                     id:           1,
@@ -576,7 +575,7 @@ impl JWT {
 
 
         assert_eq! {
-            &*repository().await.lock().await,
+            &*repository().await.lock().unwrap(),
             &HashMap::from([
                 (1, User {
                     id:           1,

--- a/ohkami/src/fang/builtin/jwt.rs
+++ b/ohkami/src/fang/builtin/jwt.rs
@@ -83,7 +83,7 @@ use crate::{Request, Response, Status};
 ///     Ohkami::with(MyAuthFang, (
 ///         "/signin".POST(signin),
 ///         "/api/profile".GET(get_profile),
-///     )).howl(3000).await
+///     )).howl("localhost:3000").await
 /// }
 /// ```
 #[derive(Clone)]

--- a/ohkami/src/fang/mod.rs
+++ b/ohkami/src/fang/mod.rs
@@ -1,6 +1,6 @@
 pub mod builtin;
 
-use std::sync::Arc;
+use std::{any::{Any, TypeId}, sync::Arc};
 use crate::{Request, Response};
 
 
@@ -52,6 +52,7 @@ use crate::{Request, Response};
 /// Hello!
 #[derive(Clone)]
 pub struct Fang {
+    id:              TypeId,
     pub(crate) proc: proc::FangProc,
 }
 impl Fang {
@@ -59,6 +60,13 @@ impl Fang {
         matches!(self.proc, proc::FangProc::Front(_))
     }
 }
+const _: () = {
+    impl<'f> PartialEq for &'f Fang {
+        fn eq(&self, other: &Self) -> bool {
+            self.id == other.id
+        }
+    }
+};
 
 pub(crate) mod proc {
     use std::sync::Arc;
@@ -94,8 +102,9 @@ const _: () = {
         /// 
         /// - `Fn(&/&mut Request)`
         /// - `Fn(&/&mut Request) -> Result<(), Response>`
-        pub fn front<M>(material: impl IntoFrontFang<M>) -> Self {
+        pub fn front<M>(material: impl IntoFrontFang<M> + 'static) -> Self {
             Self {
+                id:   material.type_id(),
                 proc: proc::FangProc::Front(material.into_front()),
             }
         }
@@ -106,8 +115,9 @@ const _: () = {
         /// - `Fn(&/&mut Response) -> Result<(), Response>`
         /// - `Fn(&/&mut Response, &Request)`
         /// - `Fn(&/&mut Response, &Request) -> Result<(), Response>`
-        pub fn back<M>(material: impl IntoBackFang<M>) -> Self {
+        pub fn back<M>(material: impl IntoBackFang<M> + 'static) -> Self {
             Self {
+                id:   material.type_id(),
                 proc: proc::FangProc::Back(material.into_back()),
             }
         }

--- a/ohkami/src/fang/mod.rs
+++ b/ohkami/src/fang/mod.rs
@@ -31,7 +31,7 @@ use crate::{Request, Response};
 ///         "/".GET(|| async {
 ///             "Hello!"
 ///         })
-///     ).howl(5000).await
+///     ).howl("localhost:5000").await
 /// }
 /// ```
 /// 

--- a/ohkami/src/handler/handlers.rs
+++ b/ohkami/src/handler/handlers.rs
@@ -75,7 +75,7 @@ macro_rules! Route {
         ///         "/hello"  // <-- `Route` works here...
         ///             .GET(greet)
         ///             .PUT(hello),
-        ///     )).howl(3000).await
+        ///     )).howl("localhost:3000").await
         /// }
         /// ```
         pub trait Route {

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -41,15 +41,9 @@ mod __rt__ {
     pub(crate) use async_std::test;
 
     #[cfg(feature="rt_tokio")]
-    pub(crate) use tokio::net::{TcpListener, TcpStream};
+    pub(crate) use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
     #[cfg(feature="rt_async-std")]
-    pub(crate) use async_std::net::{TcpListener, TcpStream};
-
-    #[cfg(feature="rt_tokio")]
-    pub(crate) use tokio::sync::Mutex;
-    #[allow(unused)]
-    #[cfg(feature="rt_async-std")]
-    pub(crate) use async_std::sync::Mutex;
+    pub(crate) use async_std::net::{TcpListener, TcpStream, ToSocketAddrs};
 
     #[cfg(feature="rt_tokio")]
     pub(crate) use tokio::task;
@@ -84,6 +78,7 @@ mod fang;
 pub use fang::{Fang, builtin};
 
 mod session;
+use session::Session;
 
 mod ohkami;
 pub use ohkami::{Ohkami, IntoFang};

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -40,15 +40,10 @@ mod __rt__ {
     #[cfg(all(feature="rt_async-std", feature="DEBUG"))]
     pub(crate) use async_std::test;
 
-    #[cfg(all(feature="websocket", feature="rt_tokio"))]
-    pub(crate) use tokio::net::TcpStream;
-    #[cfg(all(feature="websocket", feature="rt_async-std"))]
-    pub(crate) use async_std::net::TcpStream;
-
     #[cfg(feature="rt_tokio")]
-    pub(crate) use tokio::net::TcpListener;
+    pub(crate) use tokio::net::{TcpListener, TcpStream};
     #[cfg(feature="rt_async-std")]
-    pub(crate) use async_std::net::TcpListener;
+    pub(crate) use async_std::net::{TcpListener, TcpStream};
 
     #[cfg(feature="rt_tokio")]
     pub(crate) use tokio::sync::Mutex;
@@ -87,6 +82,8 @@ pub use handler::Route;
 
 mod fang;
 pub use fang::{Fang, builtin};
+
+mod session;
 
 mod ohkami;
 pub use ohkami::{Ohkami, IntoFang};

--- a/ohkami/src/ohkami/howl.rs
+++ b/ohkami/src/ohkami/howl.rs
@@ -1,120 +1,42 @@
-use std::{sync::Arc, pin::Pin};
+use std::{sync::Arc};
 use super::{Ohkami};
-use crate::{__rt__, Request};
-#[cfg(feature="rt_tokio")] use crate::Response;
+use crate::{__rt__, Session};
 
 #[cfg(feature="rt_async-std")] use crate::__rt__::StreamExt;
 #[cfg(feature="websocket")]    use crate::websocket::reserve_upgrade;
 
 
-pub trait TCPAddress {
-    fn parse(self) -> String;
-} const _: () = {
-    impl TCPAddress for u16 {
-        fn parse(self) -> String {
-            if self > 49151 {panic!("port must be 0 〜 49151")}
-            format!("0.0.0.0:{self}")
-        }
-    }
-    impl TCPAddress for &'static str {
-        fn parse(self) -> String {
-            if self.starts_with(":") {
-                format!("0.0.0.0{self}")
-            } else if self.starts_with("localhost") {
-                self.replace("localhost", "127.0.0.1")
-            } else {
-                self.to_owned()
-            }
-        }
-    }
-};
-
-
 impl Ohkami {
-    /// address :
-    /// 
-    /// - u16 `PORT` like `8080`
-    /// - literal `":{PORT}"` like `":5000"`
-    /// - literal `"localhost:{PORT}"` like `"localhost:3000"`
-    pub async fn howl(self, address: impl TCPAddress) {
+    pub async fn howl(self, address: impl __rt__::ToSocketAddrs) {
         let router = Arc::new(self.into_router().into_radix());
         
-        let listener = match __rt__::TcpListener::bind(address.parse()).await {
+        let listener = match __rt__::TcpListener::bind(address).await {
             Ok(listener) => listener,
             Err(e)       => panic!("Failed to bind TCP listener: {e}"),
         };
 
         #[cfg(feature="rt_async-std")]
-        while let Some(Ok(mut stream)) = listener.incoming().next().await {
-            let router = Arc::clone(&router);
+        while let Some(connection) = listener.incoming().next().await {
+            let Ok(connection) = connection else {continue};
 
-            __rt__::task::spawn(async move {
-                let mut req = Request::init();
-                let mut req = unsafe {Pin::new_unchecked(&mut req)};
-                req.as_mut().read(&mut stream).await;
-
-                #[cfg(not(feature="websocket"))]
-                let res = router.handle(req.get_mut()).await;
-                #[cfg(feature="websocket")]
-                let (res, upgrade_id) = router.handle(req.get_mut()).await;
-
-                res.send(&mut stream).await;
-
-                #[cfg(feature="websocket")]
-                if let Some(id) = upgrade_id {
-                    unsafe{reserve_upgrade(id, stream)}
-                }
-            }).await
+            __rt__::task::spawn({
+                Session::new(
+                    router.clone(),
+                    connection,
+                ).manage()
+            });
         }
         
         #[cfg(feature="rt_tokio")]
         loop {
-            let stream = Arc::new(__rt__::Mutex::new(
-                match listener.accept().await {
-                    Ok((stream, _)) => stream,
-                    Err(e)          => panic!("Failed to accept TCP stream: {e}"),
-                }
-            ));
+            let Ok((connection, _)) = listener.accept().await else {continue};
 
-            match __rt__::task::spawn({
-                let router = router.clone();
-                let stream = stream.clone();
-                
-                async move {
-                    let stream = &mut *stream.lock().await;
-
-                    let mut req = Request::init();
-                    let mut req = unsafe {Pin::new_unchecked(&mut req)};
-                    req.as_mut().read(stream).await;
-
-                    #[cfg(not(feature="websocket"))]
-                    let res = router.handle(req.get_mut()).await;
-                    #[cfg(feature="websocket")]
-                    let (res, upgrade_id) = router.handle(req.get_mut()).await;
-
-                    res.send(stream).await;
-
-                    #[cfg(feature="websocket")]
-                    upgrade_id
-                }
-            }).await {
-                #[cfg(not(feature="websocket"))]
-                Ok(_) => (),
-
-                #[cfg(feature="websocket")]
-                Ok(upgrade_id) => {
-                    if let Some(id) = upgrade_id {
-                        let stream = __rt__::Mutex::into_inner(Arc::into_inner(stream).unwrap());
-                        unsafe{reserve_upgrade(id, stream)}
-                    }
-                }
-
-                Err(e) => (|| async {
-                    println!("Fatal error: {e}");
-                    let res = Response::with(crate::Status::InternalServerError);
-                    res.send(&mut *stream.lock().await).await
-                })().await,
-            }
+            __rt__::task::spawn({
+                Session::new(
+                    router.clone(),
+                    connection,
+                ).manage()
+            });
         }
     }
 }

--- a/ohkami/src/ohkami/router/radix.rs
+++ b/ohkami/src/ohkami/router/radix.rs
@@ -192,7 +192,7 @@ impl Node {
         //    while `search`
         let path_bytes_maybe_percent_encoded = unsafe {req.internal_path_bytes()};
         // Decode percent encodings in `path_bytes_maybe_percent_encoded`,
-        // without checking entire it is valid UTF-8.
+        // without checking if entire it is valid UTF-8.
         let decoded = percent_decode(path_bytes_maybe_percent_encoded);
         let mut path: &[u8] = &decoded;
 

--- a/ohkami/src/ohkami/router/radix.rs
+++ b/ohkami/src/ohkami/router/radix.rs
@@ -19,6 +19,7 @@ use crate::websocket::{
 
 
 /*===== defs =====*/
+
 pub(crate) struct RadixRouter {
     pub(super) GET:    Node,
     pub(super) PUT:    Node,
@@ -72,16 +73,6 @@ pub(super) enum Pattern {
 
 
 /*===== impls =====*/
-// #[cfg(feature="websocket")] type HandleResult = (Response, Option<UpgradeID>);
-// #[cfg(feature="websocket")] fn __no_upgrade(res: Response) -> HandleResult {
-//     (res, None)
-// }
-// 
-// #[cfg(not(feature="websocket"))] type HandleResult = Response;
-// #[cfg(not(feature="websocket"))] fn __no_upgrade(res: Response) -> HandleResult {
-//     res
-// }
-
 
 impl RadixRouter {
     pub(crate) async fn handle(
@@ -261,6 +252,7 @@ impl Node {
 
 
 /*===== utils =====*/
+
 impl Node {
     #[inline] fn matchable_child(&self, path: &[u8]) -> Option<&Node> {
         for child in &self.children {

--- a/ohkami/src/ohkami/router/trie.rs
+++ b/ohkami/src/ohkami/router/trie.rs
@@ -247,7 +247,7 @@ impl Node {
                 fangs:    child_fangs,
                 handler:  child_handler,
                 children: child_children,
-            } = children.pop(/* single child */).unwrap(/* `children` is empty here */);
+            } = children.pop(/* pop the single child */).unwrap(/* `children` is empty here */);
 
             children = child_children;
             handler  = child_handler;
@@ -284,7 +284,6 @@ impl Node {
                 }
             }
         }
-        
 
         super::radix::Node {
             handler,

--- a/ohkami/src/ohkami/router/trie.rs
+++ b/ohkami/src/ohkami/router/trie.rs
@@ -1,8 +1,8 @@
-use std::{any::Any, borrow::Cow};
+use std::borrow::Cow;
 use super::{RouteSection, RouteSections};
 use crate::{
     Method,
-    fang::{proc::{BackFang, FangProc, FrontFang}, Fang},
+    fang::{proc::FangProc, Fang},
     handler::{ByAnother, Handler, Handlers}
 };
 
@@ -270,17 +270,18 @@ impl Node {
         }
 
         let (mut front, mut back) = (Vec::new(), Vec::new());
-        for f in fangs {
-            match f.proc {
-                FangProc::Front(ff) => {
-                    if front.iter().all(|f: &FrontFang| f.type_id() != ff.type_id()) {
-                        front.push(ff)
-                    }
+        {
+            let mut unique_fangs = Vec::new();
+            for f in fangs {
+                if unique_fangs.iter().all(|uf| uf != &f) {
+                    unique_fangs.push(f)
                 }
-                FangProc::Back (bf) => {
-                    if back.iter().all(|b: &BackFang| b.type_id() != bf.type_id()) {
-                        back.push(bf)
-                    }
+            }
+
+            for uf in unique_fangs {
+                match uf.proc {
+                    FangProc::Front(ff) => front.push(ff),
+                    FangProc::Back (bf) => back.push(bf),
                 }
             }
         }

--- a/ohkami/src/ohkami/router/trie.rs
+++ b/ohkami/src/ohkami/router/trie.rs
@@ -161,7 +161,7 @@ impl TrieRouter {
                         FangProc::Back(bf)  => back .push(bf),
                     }
                 }
-                (front.into_boxed_slice(), back.into_boxed_slice())
+                (Box::leak(front.into_boxed_slice()), Box::leak(back.into_boxed_slice()))
             },
             OPTIONSfangs: {
                 let (mut front, mut back) = (vec![], vec![]);
@@ -171,7 +171,7 @@ impl TrieRouter {
                         FangProc::Back(bf)  => back .push(bf),
                     }
                 }
-                (front.into_boxed_slice(), back.into_boxed_slice())
+                (Box::leak(front.into_boxed_slice()), Box::leak(back.into_boxed_slice()))
             }
         }
     }
@@ -289,12 +289,12 @@ impl Node {
         super::radix::Node {
             handler,
             children: children.into_iter().map(|c| c.into_radix()).collect(),
-            front:    front.into_boxed_slice(),
-            back:     back .into_boxed_slice(),
-            patterns: patterns
+            front:    Box::leak(front.into_boxed_slice()),
+            back:     Box::leak(back .into_boxed_slice()),
+            patterns: Box::leak(patterns
                 .into_iter()
                 .map(Pattern::into_radix)
-                .collect(),
+                .collect())
         }
     }
 }

--- a/ohkami/src/request/method.rs
+++ b/ohkami/src/request/method.rs
@@ -10,16 +10,16 @@ pub enum Method {
 }
 
 impl Method {
-    #[inline] pub(crate) fn from_bytes(bytes: &[u8]) -> Self {
+    #[inline] pub(crate) fn from_bytes(bytes: &[u8]) -> Option<Self> {
         match bytes {
-            b"GET"     => Self::GET,
-            b"PUT"     => Self::PUT,
-            b"POST"    => Self::POST,
-            b"PATCH"   => Self::PATCH,
-            b"DELETE"  => Self::DELETE,
-            b"HEAD"    => Self::HEAD,
-            b"OPTIONS" => Self::OPTIONS,
-            _ => unreachable!("unknown method: `{}`", unsafe {std::str::from_utf8_unchecked(bytes)})
+            b"GET"     => Some(Self::GET),
+            b"PUT"     => Some(Self::PUT),
+            b"POST"    => Some(Self::POST),
+            b"PATCH"   => Some(Self::PATCH),
+            b"DELETE"  => Some(Self::DELETE),
+            b"HEAD"    => Some(Self::HEAD),
+            b"OPTIONS" => Some(Self::OPTIONS),
+            _ => None
         }
     }
 

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -175,7 +175,7 @@ impl Request {
             r.consume("\r\n");
         }
 
-        let content_length = headers.get(RequestHeader::ContentLength)
+        let content_length = headers.ContentLength()
             .unwrap_or("")
             .as_bytes().into_iter()
             .fold(0, |len, b| 10*len + (*b - b'0') as usize);

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -124,10 +124,10 @@ impl Request {
         mut self: Pin<&mut Self>,
         stream:   &mut (impl AsyncReader + Unpin),
     ) -> Option<()> {
-        stream.read(&mut self._metadata).await.unwrap();
+        if stream.read(&mut self._metadata).await.ok()? == 0 {return None};
         let mut r = Reader::new(&self._metadata);
 
-        let method = Method::from_bytes(r.read_while(|b| b != &b' '))?;
+        let method = Method::from_bytes(r.read_while(|b| b != &b' ')).unwrap();
         r.consume(" ").unwrap();
         
         let path = unsafe {// SAFETY: Just calling in request parsing

--- a/ohkami/src/request/store.rs
+++ b/ohkami/src/request/store.rs
@@ -75,7 +75,16 @@ impl<'req, Value: Send + Sync + 'static> super::FromRequest<'req> for Memory<'re
     #[inline] fn from_request(req: &'req crate::Request) -> Result<Self, Self::Error> {
         req.memorized::<Value>()
             .map(Memory)
-            .ok_or_else(|| crate::FromRequestError::Static("Something went wrong"))
+            .ok_or_else(|| {
+                #[cfg(debug_assertions)] {
+                    eprintln!(
+                        "`Memory` of type `{}` was not found",
+                        std::any::type_name::<Value>(),
+                    );
+                }
+
+                crate::FromRequestError::Static("Something went wrong")
+            })
     }
 }
 impl<'req, Value: Send + Sync + 'static> std::ops::Deref for Memory<'req, Value> {

--- a/ohkami/src/response/_test.rs
+++ b/ohkami/src/response/_test.rs
@@ -1,0 +1,57 @@
+#![cfg(feature="testing")]
+
+use crate::Response;
+
+#[crate::__rt__::test]
+async fn test_response_into_bytes() {
+    macro_rules! assert_bytes_eq {
+        ($actual:expr, $expected:expr) => {
+            {
+                if &$actual != &$expected {
+                    panic!("\n\
+                        [got]\n\
+                        {}\n\
+                        [expected]\n\
+                        {}\n",
+                        ($actual).escape_ascii(),
+                        ($expected).escape_ascii(),
+                    )
+                }
+            }
+        };
+    }
+
+    let res = Response::NoContent();
+    let res_bytes = res.into_bytes();
+    assert_bytes_eq!(&res_bytes, b"\
+        HTTP/1.1 204 No Content\r\n\
+        \r\n\
+    ");
+
+    let mut res = Response::NoContent();
+    res.headers.set().Server("ohkami");
+    let res_bytes = res.into_bytes();
+    assert_bytes_eq!(&res_bytes, b"\
+        HTTP/1.1 204 No Content\r\n\
+        Server: ohkami\r\n\
+        \r\n\
+    ");
+
+    let res = Response::NotFound();
+    let res_bytes = res.into_bytes();
+    assert_bytes_eq!(&res_bytes, b"\
+        HTTP/1.1 404 Not Found\r\n\
+        Content-Length: 0\r\n\
+        \r\n\
+    ");
+
+    let mut res = Response::NotFound();
+    res.headers.set().Server("ohkami");
+    let res_bytes = res.into_bytes();
+    assert_bytes_eq!(&res_bytes, b"\
+        HTTP/1.1 404 Not Found\r\n\
+        Content-Length: 0\r\n\
+        Server: ohkami\r\n\
+        \r\n\
+    ");
+}

--- a/ohkami/src/response/into_response.rs
+++ b/ohkami/src/response/into_response.rs
@@ -31,7 +31,7 @@ use crate::{Response, Status};
 /// async fn main() {
 ///     Ohkami::new(
 ///         "/".GET(handler)
-///     ).howl(5050).await
+///     ).howl("localhost:5050").await
 /// }
 /// ```
 pub trait IntoResponse {

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -9,6 +9,9 @@ pub use headers::Header as ResponseHeader;
 mod into_response;
 pub use into_response::IntoResponse;
 
+#[cfg(test)]
+mod _test;
+
 use std::{
     borrow::Cow,
 };
@@ -101,7 +104,11 @@ pub struct Response {
 
 impl Response {
     #[inline] pub(crate) fn into_bytes(self) -> Vec<u8> {
-        let Self { status, headers, content, .. } = self;
+        let Self { status, mut headers, content, .. } = self;
+
+        if content.is_none() && !matches!(status, Status::NoContent) {
+            headers.set().ContentLength("0");
+        }
 
         let mut buf = Vec::from("HTTP/1.1 ");
         buf.extend_from_slice(status.as_bytes());

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -24,11 +24,11 @@ impl Session {
     pub(crate) async fn manage(mut self) {
         #[cold] fn panicking(panic: Box<dyn Any + Send>) -> Response {
             if let Some(msg) = panic.downcast_ref::<String>() {
-                eprintln!("Panicked: {msg}");
+                eprintln!("[Panicked]: {msg}");
             } else if let Some(msg) = panic.downcast_ref::<&str>() {
-                eprintln!("Panicked: {msg}");
+                eprintln!("[Panicked]: {msg}");
             } else {
-                eprintln!("Panicked");
+                eprintln!("[Panicked]");
             }
 
             crate::Response::InternalServerError()

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -1,0 +1,36 @@
+use std::{pin::Pin, sync::Arc};
+use crate::__rt__::{AsyncReader, AsyncWriter, Mutex, TcpStream};
+use crate::ohkami::router::RadixRouter;
+use crate::Request;
+
+
+pub(crate) struct Session {
+    router:     Arc<RadixRouter>,
+    connection: TcpStream,
+}
+impl Session {
+    pub(crate) fn new(
+        router:     Arc<RadixRouter>,
+        connection: TcpStream,
+    ) -> Self {
+        Self {
+            router,
+            connection,
+        }
+    }
+
+    pub(crate) async fn manage(mut self) {
+        let connection = &mut self.connection;
+
+        {
+            let mut req = Request::init();
+            let mut req = unsafe {Pin::new_unchecked(&mut req)};
+            req.as_mut().read(connection).await;
+
+            let res = self.router.handle(req.get_mut()).await;
+            res.send(connection).await;
+        }
+
+        todo!()
+    }
+}

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -41,7 +41,7 @@ impl Session {
         for _ in 0..LOOP_LIMIT {
             let mut req = Request::init();
             let mut req = unsafe {Pin::new_unchecked(&mut req)};
-            req.as_mut().read(connection).await;
+            if req.as_mut().read(connection).await.is_none() {break}
 
             let close = req.headers.Connection().is_some_and(|c| c == "close");
 

--- a/ohkami/src/utils/now.rs
+++ b/ohkami/src/utils/now.rs
@@ -384,13 +384,5 @@ enum Weekday {
 
         let (cn, n) = (correct_now(), super::imf_fixdate_now());
         assert_eq!(cn, n);
-
-        std::thread::sleep(std::time::Duration::from_secs_f64(1.05));
-        let (cn, n) = (correct_now(), super::imf_fixdate_now());
-        assert_eq!(cn, n);
-
-        std::thread::sleep(std::time::Duration::from_secs_f64(3.14));
-        let (cn, n) = (correct_now(), super::imf_fixdate_now());
-        assert_eq!(cn, n);
     }
 }


### PR DESCRIPTION
- Fix to include serde with `derive` feature
  - And fix `examples` workspace to use ohkami with `default-features = false` to always emit `DEBUG` feature
- Implement correct connection handling required in HTTP/1.1
- Fix `Fang` registeration to assure that duplicated (same) fangs are merged to one
- Improve error messages or some things for developers
- Update docs