### PR TITLE
Fix around request handling

### DIFF
--- a/examples/realworld/src/main.rs
+++ b/examples/realworld/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), errors::RealWorldError> {
         .map_err(|e| RealWorldError::DB(e))?;
 
     handlers::realworld_ohkami(pool)
-        .howl(":8080").await;
+        .howl("localhost:8080").await;
 
     Ok(())
 }

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -29,7 +29,7 @@ hmac          = { version = "=0.13.0-pre.0", default-features = false }
 rustc-hash    = { version = "1.1", optional = true }
 
 [features]
-#default       = ["utils", "testing"]
+default       = ["utils", "testing"]
 rt_tokio      = ["dep:tokio"]
 rt_async-std  = ["dep:async-std"]
 utils         = []
@@ -44,12 +44,12 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-default = [
-    "utils",
-    "testing",
-    "custom-header",
-    #"websocket",
-    "rt_tokio",
-    #"rt_async-std",
-    "DEBUG",
-]
+#default = [
+#    "utils",
+#    "testing",
+#    "custom-header",
+#    #"websocket",
+#    "rt_tokio",
+#    #"rt_async-std",
+#    "DEBUG",
+#]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -29,7 +29,7 @@ hmac          = { version = "=0.13.0-pre.0", default-features = false }
 rustc-hash    = { version = "1.1", optional = true }
 
 [features]
-default       = ["utils", "testing"]
+#default       = ["utils", "testing"]
 rt_tokio      = ["dep:tokio"]
 rt_async-std  = ["dep:async-std"]
 utils         = []
@@ -44,12 +44,12 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-#default = [
-#    "utils",
-#    "testing",
-#    "custom-header",
-#    #"websocket",
-#    "rt_tokio",
-#    #"rt_async-std",
-#    "DEBUG",
-#]
+default = [
+    "utils",
+    "testing",
+    "custom-header",
+    #"websocket",
+    "rt_tokio",
+    #"rt_async-std",
+    "DEBUG",
+]

--- a/ohkami/src/fang/fangs.rs
+++ b/ohkami/src/fang/fangs.rs
@@ -22,6 +22,8 @@ use crate::{Response, Request, Method::{self, *}, fang::Fang};
 pub trait FrontFang {
     const METHODS: &'static [Method] = &[GET, PUT, POST, PATCH, DELETE, HEAD, OPTIONS];
 
+    #[must_use]
+    #[allow(clippy::type_complexity)]
     fn bite(&self, req: &mut Request) -> impl ::std::future::Future<Output = Result<(), Response>> + Send;
 }
 
@@ -58,6 +60,8 @@ impl<FF: FrontFang + Send + Sync> FrontFangCaller for FF {
 pub trait BackFang {
     const METHODS: &'static [Method] = &[GET, PUT, POST, PATCH, DELETE, HEAD, OPTIONS];
 
+    #[must_use]
+    #[allow(clippy::type_complexity)]
     fn bite(&self, res: &mut Response, _req: &Request) -> impl ::std::future::Future<Output = Result<(), Response>> + Send;
 }
 

--- a/ohkami/src/ohkami/build.rs
+++ b/ohkami/src/ohkami/build.rs
@@ -73,4 +73,12 @@ pub trait Routes {
     impl_for_tuple!(R1, R2, R3, R4, R5, R6);
     impl_for_tuple!(R1, R2, R3, R4, R5, R6, R7);
     impl_for_tuple!(R1, R2, R3, R4, R5, R6, R7, R8);
+    impl_for_tuple!(R1, R2, R3, R4, R5, R6, R7, R8, R9);
+    impl_for_tuple!(R1, R2, R3, R4, R5, R6, R7, R8, R9, R10);
+    impl_for_tuple!(R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11);
+    impl_for_tuple!(R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12);
+    impl_for_tuple!(R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13);
+    impl_for_tuple!(R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14);
+    impl_for_tuple!(R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15);
+    impl_for_tuple!(R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16);
 };

--- a/ohkami/src/ohkami/router/_test.rs
+++ b/ohkami/src/ohkami/router/_test.rs
@@ -3,6 +3,7 @@ use crate::prelude::*;
 use crate::testing::*;
 use crate::utils::Text;
 
+
 fn my_ohkami() -> Ohkami {
     let health_ohkami = Ohkami::new((
         "/".GET(|| async {Text("health_check")}),
@@ -69,8 +70,7 @@ fn my_ohkami() -> Ohkami {
     ))
 }
 
-#[cfg(feature="testing")]
-#[crate::__rt__::test] async fn test_router() {
+#[crate::__rt__::test] async fn test_handler_registration() {
     let t = my_ohkami();
 
 
@@ -137,4 +137,45 @@ fn my_ohkami() -> Ohkami {
     let req = TestRequest::DELETE("/api/articles/__prototype__/comments/42");
     let res = t.oneshot(req).await;
     assert_eq!(res.text(), Some("delete_comment __prototype__ / 42"));
+}
+
+
+#[crate::__rt__::test] async fn test_fang_registration() {
+    use std::sync::{OnceLock, Mutex};
+    use crate::FrontFang;
+
+    fn N() -> &'static Mutex<usize> {
+        static N: OnceLock<Mutex<usize>> = OnceLock::new();
+        N.get_or_init(|| Mutex::new(0))
+    }
+
+    struct Increment;
+    impl FrontFang for Increment {
+        fn bite(&self, _: &mut Request) -> impl std::future::Future<Output = Result<(), Response>> + Send {
+            *N().lock().unwrap() += 1;
+
+            async {Ok(())}
+        }
+    }
+
+    async fn h() -> &'static str {"h"}
+
+    let o = Ohkami::with(Increment, (
+        "/a"  .GET(h),
+        "/a/b".GET(h),
+    ));
+
+//    let req = TestRequest::GET("/a");
+//    o.oneshot(req).await;
+//    assert_eq!(*N().lock().unwrap(), 1);
+//
+//    let req = TestRequest::GET("/a");
+//    o.oneshot(req).await;
+//    assert_eq!(*N().lock().unwrap(), 2);
+
+    let req = TestRequest::GET("/a/b");
+    o.oneshot(req).await;
+    assert_eq!(*N().lock().unwrap(), 3);
+
+    panic!()
 }

--- a/ohkami/src/ohkami/router/_test.rs
+++ b/ohkami/src/ohkami/router/_test.rs
@@ -165,13 +165,13 @@ fn my_ohkami() -> Ohkami {
         "/a/b".GET(h),
     ));
 
-//    let req = TestRequest::GET("/a");
-//    o.oneshot(req).await;
-//    assert_eq!(*N().lock().unwrap(), 1);
-//
-//    let req = TestRequest::GET("/a");
-//    o.oneshot(req).await;
-//    assert_eq!(*N().lock().unwrap(), 2);
+    let req = TestRequest::GET("/a");
+    o.oneshot(req).await;
+    assert_eq!(*N().lock().unwrap(), 1);
+
+    let req = TestRequest::GET("/a");
+    o.oneshot(req).await;
+    assert_eq!(*N().lock().unwrap(), 2);
 
     let req = TestRequest::GET("/a/b");
     o.oneshot(req).await;

--- a/ohkami/src/ohkami/router/_test.rs
+++ b/ohkami/src/ohkami/router/_test.rs
@@ -176,6 +176,4 @@ fn my_ohkami() -> Ohkami {
     let req = TestRequest::GET("/a/b");
     o.oneshot(req).await;
     assert_eq!(*N().lock().unwrap(), 3);
-
-    panic!()
 }

--- a/ohkami/src/ohkami/router/radix.rs
+++ b/ohkami/src/ohkami/router/radix.rs
@@ -200,6 +200,9 @@ impl Node {
         println!("[path] '{}'", path.escape_ascii());
 
         loop {
+            #[cfg(feature="DEBUG")]
+            println!("[target] {:?}", target);
+
             for ff in target.front {
                 ff.0.call(req).await?
             }

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -210,7 +210,7 @@ const _: () = {
                 Some(cow) => f.debug_struct("Response")
                     .field("status",  &self.status)
                     .field("headers", &self.headers)
-                    .field("content", &cow.escape_ascii())
+                    .field("content", &cow.escape_ascii().to_string())
                     .finish(),
             }
         }


### PR DESCRIPTION
- `Response`'s `content`: display with `.escape_ascii().to_string()` in `Debug`
- Add `#[must_use]`, `#[allow(clippy::type_complexity)]` in `{Front,Back}Fang::bite`
- Update max route items: 8 -> 16