### PR TITLE
Update router sort children by pattern

### DIFF
--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -29,12 +29,11 @@ hmac          = { version = "0.12.1", default-features = false }
 rustc-hash    = { version = "1.1", optional = true }
 
 [features]
-default       = ["testing"]
+#default       = ["testing"]
 rt_tokio      = ["dep:tokio"]
 rt_async-std  = ["dep:async-std"]
 testing       = []
 custom-header = ["dep:rustc-hash"]
-#static-files  = []
 #websocket    = ["dep:sha1"]
 #sse          = []
 
@@ -44,11 +43,11 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-#default = [
-#    "testing",
-#    "custom-header",
-#    #"websocket",
-#    "rt_tokio",
-#    #"rt_async-std",
-#    "DEBUG",
-#]
+default = [
+    "testing",
+    "custom-header",
+    #"websocket",
+    "rt_tokio",
+    #"rt_async-std",
+    "DEBUG",
+]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -29,7 +29,7 @@ hmac          = { version = "0.12.1", default-features = false }
 rustc-hash    = { version = "1.1", optional = true }
 
 [features]
-#default       = ["testing"]
+default       = ["testing"]
 rt_tokio      = ["dep:tokio"]
 rt_async-std  = ["dep:async-std"]
 testing       = []
@@ -43,11 +43,11 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-default = [
-    "testing",
-    "custom-header",
-    #"websocket",
-    "rt_tokio",
-    #"rt_async-std",
-    "DEBUG",
-]
+#default = [
+#    "testing",
+#    "custom-header",
+#    #"websocket",
+#    "rt_tokio",
+#    #"rt_async-std",
+#    "DEBUG",
+#]

--- a/ohkami/src/handler/into_handler.rs
+++ b/ohkami/src/handler/into_handler.rs
@@ -18,7 +18,10 @@ pub trait IntoHandler<T> {
 ) -> Result<P, Response> {
     let param = percent_decode_utf8(param_bytes_maybe_percent_encoded)
         .map_err(|_e| {
-            #[cfg(debug_assertions)] eprintln!("Failed to decode percent encoding: {_e}");
+            #[cfg(debug_assertions)] eprintln!(
+                "[WARNING] Failed to decode percent encoding `{}`: {_e}",
+                param_bytes_maybe_percent_encoded.escape_ascii()
+            );
             Response::InternalServerError()
         })?;
 

--- a/ohkami/src/ohkami/router/_test.rs
+++ b/ohkami/src/ohkami/router/_test.rs
@@ -374,7 +374,7 @@ fn my_ohkami() -> Ohkami {
         \t `GET /hello/{you name here}`"
     }
 
-    async fn hello(name: &str) -> String {
+    async fn hello(name: std::borrow::Cow<'_, str>) -> String {
         format!("Hello, {name}!")
     }
 

--- a/ohkami/src/ohkami/router/radix.rs
+++ b/ohkami/src/ohkami/router/radix.rs
@@ -7,7 +7,7 @@ use crate::{
     builtin::fang::Timeout,
 };
 use super::super::timeout::set_timeout;
-use ohkami_lib::{Slice, percent_decode};
+use ohkami_lib::Slice;
 use std::fmt::Write;
 
 
@@ -308,17 +308,13 @@ impl Node {
 
     pub(super/* for test */) fn search(&self, req: &mut Request) -> Option<&Node> {
         let mut target = self;
-
+        
         // SAFETY:
         // 1. `req` must be alive while `search`
         // 2. `Request` DOESN'T have method that mutates `path`,
         //    So what `path` refers to is NEVER changed by any other process
         //    while `search`
-        let path_bytes_maybe_percent_encoded = unsafe {req.internal_path_bytes()};
-        // Decode percent encodings in `path_bytes_maybe_percent_encoded`,
-        // without checking if entire it is valid UTF-8.
-        let decoded = percent_decode(path_bytes_maybe_percent_encoded);
-        let mut path: &[u8] = &decoded;
+        let mut path = unsafe {req.internal_path_bytes()};
 
         #[cfg(feature="DEBUG")]
         println!("[path] '{}'", path.escape_ascii());

--- a/ohkami/src/ohkami/router/trie.rs
+++ b/ohkami/src/ohkami/router/trie.rs
@@ -337,6 +337,12 @@ impl Node {
             }
         }
 
+        // children.sort_unstable_by(|a, b| match (a.pattern.as_ref().unwrap(), b.pattern.as_ref().unwrap()) {
+        //     (Pattern::Static(_), Pattern::Param) => std::cmp::Ordering::Less,
+        //     (Pattern::Param, Pattern::Static(_)) => std::cmp::Ordering::Greater,
+        //     _ => std::cmp::Ordering::Equal
+        // });
+
         let (front, back, timeout) = split_fangs(fangs);
 
         super::radix::Node {
@@ -345,7 +351,10 @@ impl Node {
             front,
             back,
             patterns: Box::leak(patterns.into_iter().map(Pattern::into_radix).collect()),
-            children: children.into_iter().map(Node::into_radix).collect(),
+            children: {
+
+                children.into_iter().map(Node::into_radix).collect()
+            }
         }
     }
 }

--- a/ohkami/src/ohkami/router/trie.rs
+++ b/ohkami/src/ohkami/router/trie.rs
@@ -337,11 +337,11 @@ impl Node {
             }
         }
 
-        // children.sort_unstable_by(|a, b| match (a.pattern.as_ref().unwrap(), b.pattern.as_ref().unwrap()) {
-        //     (Pattern::Static(_), Pattern::Param) => std::cmp::Ordering::Less,
-        //     (Pattern::Param, Pattern::Static(_)) => std::cmp::Ordering::Greater,
-        //     _ => std::cmp::Ordering::Equal
-        // });
+        children.sort_unstable_by(|a, b| match (a.pattern.as_ref().unwrap(), b.pattern.as_ref().unwrap()) {
+            (Pattern::Static(_), Pattern::Param) => std::cmp::Ordering::Less,
+            (Pattern::Param, Pattern::Static(_)) => std::cmp::Ordering::Greater,
+            _ => std::cmp::Ordering::Equal
+        });
 
         let (front, back, timeout) = split_fangs(fangs);
 

--- a/ohkami/src/request/from_request.rs
+++ b/ohkami/src/request/from_request.rs
@@ -122,10 +122,14 @@ pub trait FromParam<'p>: Sized {
         fn from_param(param: Cow<'p, str>) -> Result<Self, Self::Error> {
             #[cold] fn unexpectedly_percent_encoded() -> FromRequestError {
                 eprintln!("\
+                    \n\
+                    =========\n\
                     [WARNING] \
                     `&str` can't handle percent encoded parameters. \
-                    Use `Cow<'_, str>` or `String` instead \
-                    to handle them.");
+                    Use `Cow<'_, str>` (or `String` instead) \
+                    to handle them.\n\
+                    =========\n\
+                ");
                 FromRequestError::Owned(format!(    
                     "Unexpected path params: percent encoded"
                 ))

--- a/ohkami/src/testing/mod.rs
+++ b/ohkami/src/testing/mod.rs
@@ -39,7 +39,10 @@ use std::{pin::Pin, future::Future, format as f};
 
 
 pub trait Testing {
+    #[must_use]
     fn oneshot_with<T>(&self, global_fangs: impl Fangs<T>, req: TestRequest) -> Oneshot;
+    
+    #[must_use]
     fn oneshot(&self, req: TestRequest) -> Oneshot {
         self.oneshot_with((), req)
     }

--- a/ohkami_lib/Cargo.toml
+++ b/ohkami_lib/Cargo.toml
@@ -12,9 +12,6 @@ keywords         = ["async", "http", "web", "server", "framework"]
 categories       = ["asynchronous", "web-programming::http-server"]
 license          = "MIT"
 
-[features]
-mime             = []
-
 [dependencies]
 serde            = { version = "1.0" }
 percent-encoding = { version = "2.3" }


### PR DESCRIPTION
Now `Ohkami`'s routing depend on registration order :

```rs
let o = Ohkami::new((
    "/hello/:name".GET(hello),
    "/hello/help" .GET(hello_help),
));
```
Here we expect `GET /hello/help` is handled by `hello_help` of course, but actually done by `hello` ( and returns `hello, help` ! )

This is because the router performs route-matching just in order where they're registered, then any GET request to `/hello/*` matches to `hello/:name` and handled by `hello`.

This PR resolves this problem by sorting every children nodes of `TrieRouter` just before it is transformed to `RadixRouter` in order `static < param`.

_NOTE_: additionally fixed a bug found when adding a test for the sorting: unnecessary percent-decoding of request path. 