### PR TITLE
More correct and efficient req res

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -16,12 +16,13 @@ tasks:
   bench_dryrun:
     dir: benches
     cmds:
-      - cargo bench --no-run
+      - cargo bench --features DEBUG --no-run
+      - cargo check --bin hello
 
   bench:
     dir: benches
     cmds:
-      - cargo bench
+      - cargo bench --features DEBUG
 
 #### tests ####
   test_doc:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -28,7 +28,7 @@ tasks:
     dir: ohkami
     cmds:
       - cargo test --doc --features DEBUG,rt_tokio
-      - cargo test --doc --features DEBUG,rt_tokio,custom-header
+      - cargo test --doc --features DEBUG,rt_tokio
 
   test_examples:
     dir: examples
@@ -46,8 +46,6 @@ tasks:
     cmds:
       - cargo test --lib --no-default-features --features rt_tokio,DEBUG,{{.MAYBE_NIGHTLY}}
       - cargo test --lib --no-default-features --features rt_tokio,DEBUG,testing,{{.MAYBE_NIGHTLY}}
-      - cargo test --lib --no-default-features --features rt_tokio,DEBUG,custom-header,{{.MAYBE_NIGHTLY}}
-      - cargo test --lib --no-default-features --features rt_tokio,DEBUG,custom-header,testing,{{.MAYBE_NIGHTLY}}
 
   test_rt_async-std:
     vars:
@@ -57,8 +55,6 @@ tasks:
     cmds:
       - cargo test --lib --no-default-features --features rt_async-std,DEBUG,{{.MAYBE_NIGHTLY}}
       - cargo test --lib --no-default-features --features rt_async-std,DEBUG,testing,{{.MAYBE_NIGHTLY}}
-      - cargo test --lib --no-default-features --features rt_async-std,DEBUG,custom-header,{{.MAYBE_NIGHTLY}}
-      - cargo test --lib --no-default-features --features rt_async-std,DEBUG,custom-header,testing,{{.MAYBE_NIGHTLY}}
 
 #### checks ####
   # Assure buildability without "DEBUG" feature
@@ -71,8 +67,6 @@ tasks:
     cmds:
       - cargo check --lib --no-default-features --features rt_tokio,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --no-default-features --features rt_tokio,testing,{{.MAYBE_NIGHTLY}}
-      - cargo check --lib --no-default-features --features custom-header,rt_tokio,{{.MAYBE_NIGHTLY}}
-      - cargo check --lib --no-default-features --features custom-header,rt_tokio,testing,{{.MAYBE_NIGHTLY}}
 
   check_rt_async-std:
     vars:
@@ -82,5 +76,3 @@ tasks:
     cmds:
       - cargo check --lib --no-default-features --features rt_async-std,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --no-default-features --features rt_async-std,testing,{{.MAYBE_NIGHTLY}}
-      - cargo check --lib --no-default-features --features custom-header,rt_async-std,{{.MAYBE_NIGHTLY}}
-      - cargo check --lib --no-default-features --features custom-header,rt_async-std,testing,{{.MAYBE_NIGHTLY}}

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -5,7 +5,7 @@ edition    = "2021"
 authors    = ["kanarus <kanarus786@gmail.com>"]
 
 [dependencies]
-ohkami      = { version = "0.16.0", path = "../ohkami", features = ["rt_tokio", "custom-header", "DEBUG"] }
+ohkami      = { version = "0.16.0", path = "../ohkami", features = ["rt_tokio", "DEBUG"] }
 ohkami_lib  = { version = "0.2.0", path = "../ohkami_lib" }
 http        = "1.0.0"
 rustc-hash  = "1.1"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,13 +1,20 @@
 [package]
-name       = "ohkami_benches"
-version    = "0.0.0"
-edition    = "2021"
-authors    = ["kanarus <kanarus786@gmail.com>"]
+name    = "ohkami_benches"
+version = "0.0.0"
+edition = "2021"
+authors = ["kanarus <kanarus786@gmail.com>"]
+
+[features]
+DEBUG = ["ohkami/DEBUG"]
 
 [dependencies]
-ohkami      = { version = "0.16.0", path = "../ohkami", features = ["rt_tokio", "DEBUG"] }
-ohkami_lib  = { version = "0.2.0", path = "../ohkami_lib" }
-http        = "1.0.0"
-rustc-hash  = "1.1"
-bytes       = "1.5.0"
-byte_reader = "3.0.0"
+ohkami             = { version = "0.16.0", path = "../ohkami", features = ["rt_tokio"] }
+ohkami_lib         = { version = "0.2.0", path = "../ohkami_lib" }
+http               = "1.0.0"
+rustc-hash         = "1.1"
+bytes              = "1.5.0"
+byte_reader        = "3.0.0"
+
+tokio              = { version = "1.37.0", features = ["full"] }
+tracing            = "0.1.4"
+tracing-subscriber = "0.3.18"

--- a/benches/benches/request_headers.rs
+++ b/benches/benches/request_headers.rs
@@ -40,7 +40,7 @@ Cache-Control: no-cache\r\n\
     b.iter(|| {
         let mut r = byte_reader::Reader::new(test::black_box(INPUT));
 
-        let mut h = RequestHeaders::__init__();
+        let mut h = RequestHeaders::_init();
         while r.consume("\r\n").is_none() {
             let key_bytes = r.read_while(|b| b != &b':');
             r.consume(": ").unwrap();

--- a/benches/benches/request_headers.rs
+++ b/benches/benches/request_headers.rs
@@ -1,6 +1,10 @@
 #![feature(test)]
 extern crate test;
 
+// use test::black_box;
+fn black_box<T>(t: T) -> T {t}
+
+use http::{HeaderMap, HeaderName, HeaderValue};
 use ohkami::__internal__::{RequestHeaders, RequestHeader};
 use ohkami_lib::{CowSlice, Slice};
 
@@ -38,7 +42,7 @@ Cache-Control: no-cache\r\n\
 
 #[bench] fn ohkami_parse(b: &mut test::Bencher) {
     b.iter(|| {
-        let mut r = byte_reader::Reader::new(test::black_box(INPUT));
+        let mut r = byte_reader::Reader::new(black_box(INPUT));
 
         let mut h = RequestHeaders::_init();
         while r.consume("\r\n").is_none() {
@@ -61,7 +65,7 @@ Cache-Control: no-cache\r\n\
 
 #[bench] fn heap_ohkami_parse(b: &mut test::Bencher) {
     b.iter(|| {
-        let mut r = byte_reader::Reader::new(test::black_box(INPUT));
+        let mut r = byte_reader::Reader::new(black_box(INPUT));
 
         let mut h = HeapOhkamiHeaders::new();
         while r.consume("\r\n").is_none() {
@@ -84,7 +88,7 @@ Cache-Control: no-cache\r\n\
 
 #[bench] fn fxmap_parse(b: &mut test::Bencher) {
     b.iter(|| {
-        let mut r = byte_reader::Reader::new(test::black_box(INPUT));
+        let mut r = byte_reader::Reader::new(black_box(INPUT));
 
         let mut h = FxMap::new();
         while r.consume("\r\n").is_none() {
@@ -94,6 +98,23 @@ Cache-Control: no-cache\r\n\
                 unsafe {Slice::from_bytes(key_bytes)},
                 CowSlice::Ref(unsafe {Slice::from_bytes(r.read_while(|b| b != &b'\r'))}
             ));
+            r.consume("\r\n");
+        }
+    })
+}
+
+#[bench] fn http_parse(b: &mut test::Bencher) {
+    b.iter(|| {
+        let mut r = byte_reader::Reader::new(black_box(INPUT));
+        
+        let mut h = HeaderMap::new();
+        while r.consume("\r\n").is_none() {
+            let key_bytes = r.read_while(|b| b != &b':');
+            r.consume(": ").unwrap();
+            h.insert(
+                HeaderName::from_bytes(key_bytes).unwrap(),
+                HeaderValue::from_bytes(r.read_while(|b| b != &b'\r')).unwrap(),
+            );
             r.consume("\r\n");
         }
     })

--- a/benches/benches/response_headers.rs
+++ b/benches/benches/response_headers.rs
@@ -40,6 +40,27 @@ use ohkami_benches::response_headers::{
         ;
     });
 }
+#[bench] fn insert_ohkami_only_standard(b: &mut test::Bencher) {
+    let mut h = ResponseHeaders::_new();
+    b.iter(|| {
+        h.set()
+            .AccessControlAllowCredentials(black_box("true"))
+            .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+            .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+            .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+            .AccessControlMaxAge(black_box("86400"))
+            .Vary(black_box("Origin"))
+            .Server(black_box("ohkami"))
+            .Connection(black_box("Keep-Alive"))
+            .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+            .Via(black_box("HTTP/1.1 GWA"))
+            .AltSvc(black_box("h2=\":433\"; ma=2592000;"))
+            .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+            .ReferrerPolicy(black_box("same-origin"))
+            .XFrameOptions(black_box("DENY"))
+        ;
+    });
+}
 
 #[bench] fn insert_heap_ohkami(b: &mut test::Bencher) {
     let mut h = HeapOhkamiHeaders::new();
@@ -84,6 +105,27 @@ use ohkami_benches::response_headers::{
             .XFrameOptions(black_box("DENY"))
             .custom("x-myapp-data", black_box("myappdata; excellent"))
             .custom("something", black_box("anything"))
+        ;
+    });
+}
+#[bench] fn insert_heap_ohkami_only_standard(b: &mut test::Bencher) {
+    let mut h = HeapOhkamiHeaders::new();
+    b.iter(|| {
+        h.set()
+            .AccessControlAllowCredentials(black_box("true"))
+            .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+            .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+            .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+            .AccessControlMaxAge(black_box("86400"))
+            .Vary(black_box("Origin"))
+            .Server(black_box("ohkami"))
+            .Connection(black_box("Keep-Alive"))
+            .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+            .Via(black_box("HTTP/1.1 GWA"))
+            .AltSvc(black_box("h2=\":433\"; ma=2592000;"))
+            .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+            .ReferrerPolicy(black_box("same-origin"))
+            .XFrameOptions(black_box("DENY"))
         ;
     });
 }

--- a/benches/benches/response_headers.rs
+++ b/benches/benches/response_headers.rs
@@ -1,6 +1,9 @@
 #![feature(test)]
 extern crate test;
 
+// use test::black_box;
+fn black_box<T>(t: T) -> T {t}
+
 use ohkami::__internal__::ResponseHeaders;
 use http::{header, HeaderMap, HeaderName, HeaderValue};
 use ohkami_benches::
@@ -18,22 +21,22 @@ use ohkami_benches::response_headers::{
     let mut h = ResponseHeaders::_new();
     b.iter(|| {
         h.set()
-            .AccessControlAllowCredentials(test::black_box("true"))
-            .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-            .AccessControlAllowOrigin(test::black_box("https://foo.bar.org"))
-            .AccessControlAllowMethods(test::black_box("POST,GET,OPTIONS,DELETE"))
-            .AccessControlMaxAge(test::black_box("86400"))
-            .Vary(test::black_box("Origin"))
-            .Server(test::black_box("ohkami"))
-            .Connection(test::black_box("Keep-Alive"))
-            .Date(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-            .Via(test::black_box("HTTP/1.1 GWA"))
-            .AltSvc(test::black_box("h2=\":433\"; ma=2592000;"))
-            .ProxyAuthenticate(test::black_box("Basic realm=\"Access to the internal site\""))
-            .ReferrerPolicy(test::black_box("same-origin"))
-            .XFrameOptions(test::black_box("DENY"))
-            .custom("x-myapp-data", test::black_box("myappdata; excellent"))
-            .custom("something", test::black_box("anything"))
+            .AccessControlAllowCredentials(black_box("true"))
+            .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+            .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+            .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+            .AccessControlMaxAge(black_box("86400"))
+            .Vary(black_box("Origin"))
+            .Server(black_box("ohkami"))
+            .Connection(black_box("Keep-Alive"))
+            .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+            .Via(black_box("HTTP/1.1 GWA"))
+            .AltSvc(black_box("h2=\":433\"; ma=2592000;"))
+            .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+            .ReferrerPolicy(black_box("same-origin"))
+            .XFrameOptions(black_box("DENY"))
+            .custom("x-myapp-data", black_box("myappdata; excellent"))
+            .custom("something", black_box("anything"))
         ;
     });
 }
@@ -42,22 +45,22 @@ use ohkami_benches::response_headers::{
     let mut h = HeapOhkamiHeaders::new();
     b.iter(|| {
         h.set()
-            .AccessControlAllowCredentials(test::black_box("true"))
-            .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-            .AccessControlAllowOrigin(test::black_box("https://foo.bar.org"))
-            .AccessControlAllowMethods(test::black_box("POST,GET,OPTIONS,DELETE"))
-            .AccessControlMaxAge(test::black_box("86400"))
-            .Vary(test::black_box("Origin"))
-            .Server(test::black_box("ohkami"))
-            .Connection(test::black_box("Keep-Alive"))
-            .Date(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-            .Via(test::black_box("HTTP/1.1 GWA"))
-            .AltSvc(test::black_box("h2=\":433\"; ma=2592000;"))
-            .ProxyAuthenticate(test::black_box("Basic realm=\"Access to the internal site\""))
-            .ReferrerPolicy(test::black_box("same-origin"))
-            .XFrameOptions(test::black_box("DENY"))
-            .custom("x-myapp-data", test::black_box("myappdata; excellent"))
-            .custom("something", test::black_box("anything"))
+            .AccessControlAllowCredentials(black_box("true"))
+            .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+            .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+            .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+            .AccessControlMaxAge(black_box("86400"))
+            .Vary(black_box("Origin"))
+            .Server(black_box("ohkami"))
+            .Connection(black_box("Keep-Alive"))
+            .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+            .Via(black_box("HTTP/1.1 GWA"))
+            .AltSvc(black_box("h2=\":433\"; ma=2592000;"))
+            .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+            .ReferrerPolicy(black_box("same-origin"))
+            .XFrameOptions(black_box("DENY"))
+            .custom("x-myapp-data", black_box("myappdata; excellent"))
+            .custom("something", black_box("anything"))
         ;
     });
 }
@@ -65,22 +68,22 @@ use ohkami_benches::response_headers::{
     let mut h = HeapOhkamiHeadersWithoutSize::new();
     b.iter(|| {
         h.set()
-            .AccessControlAllowCredentials(test::black_box("true"))
-            .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-            .AccessControlAllowOrigin(test::black_box("https://foo.bar.org"))
-            .AccessControlAllowMethods(test::black_box("POST,GET,OPTIONS,DELETE"))
-            .AccessControlMaxAge(test::black_box("86400"))
-            .Vary(test::black_box("Origin"))
-            .Server(test::black_box("ohkami"))
-            .Connection(test::black_box("Keep-Alive"))
-            .Date(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-            .Via(test::black_box("HTTP/1.1 GWA"))
-            .AltSvc(test::black_box("h2=\":433\"; ma=2592000;"))
-            .ProxyAuthenticate(test::black_box("Basic realm=\"Access to the internal site\""))
-            .ReferrerPolicy(test::black_box("same-origin"))
-            .XFrameOptions(test::black_box("DENY"))
-            .custom("x-myapp-data", test::black_box("myappdata; excellent"))
-            .custom("something", test::black_box("anything"))
+            .AccessControlAllowCredentials(black_box("true"))
+            .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+            .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+            .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+            .AccessControlMaxAge(black_box("86400"))
+            .Vary(black_box("Origin"))
+            .Server(black_box("ohkami"))
+            .Connection(black_box("Keep-Alive"))
+            .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+            .Via(black_box("HTTP/1.1 GWA"))
+            .AltSvc(black_box("h2=\":433\"; ma=2592000;"))
+            .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+            .ReferrerPolicy(black_box("same-origin"))
+            .XFrameOptions(black_box("DENY"))
+            .custom("x-myapp-data", black_box("myappdata; excellent"))
+            .custom("something", black_box("anything"))
         ;
     });
 }
@@ -88,22 +91,22 @@ use ohkami_benches::response_headers::{
 #[bench] fn insert_http(b: &mut test::Bencher) {
     let mut h = HeaderMap::new();
     b.iter(|| {
-        h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(test::black_box("true")));
-        h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
-        h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(test::black_box("https://foo.bar.org")));
-        h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(test::black_box("POST,GET,OPTIONS,DELETE")));
-        h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(test::black_box("86400")));
-        h.insert(header::VARY, HeaderValue::from_static(test::black_box("Origin")));
-        h.insert(header::SERVER, HeaderValue::from_static(test::black_box("ohkami")));
-        h.insert(header::CONNECTION, HeaderValue::from_static(test::black_box("Keep-Alive")));
-        h.insert(header::DATE, HeaderValue::from_static(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT")));
-        h.insert(header::VIA, HeaderValue::from_static(test::black_box("HTTP/1.1 GWA")));
-        h.insert(header::ALT_SVC, HeaderValue::from_static(test::black_box("h2=\":433\"; ma=2592000;")));
-        h.insert(header::PROXY_AUTHENTICATE, HeaderValue::from_static(test::black_box("Basic realm=\"Access to the internal site\"")));
+        h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(black_box("true")));
+        h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
+        h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(black_box("https://foo.bar.org")));
+        h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(black_box("POST,GET,OPTIONS,DELETE")));
+        h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(black_box("86400")));
+        h.insert(header::VARY, HeaderValue::from_static(black_box("Origin")));
+        h.insert(header::SERVER, HeaderValue::from_static(black_box("ohkami")));
+        h.insert(header::CONNECTION, HeaderValue::from_static(black_box("Keep-Alive")));
+        h.insert(header::DATE, HeaderValue::from_static(black_box("Wed, 21 Oct 2015 07:28:00 GMT")));
+        h.insert(header::VIA, HeaderValue::from_static(black_box("HTTP/1.1 GWA")));
+        h.insert(header::ALT_SVC, HeaderValue::from_static(black_box("h2=\":433\"; ma=2592000;")));
+        h.insert(header::PROXY_AUTHENTICATE, HeaderValue::from_static(black_box("Basic realm=\"Access to the internal site\"")));
         h.insert(header::REFERRER_POLICY, HeaderValue::from_static("same-origin"));
         h.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
-        h.insert(HeaderName::from_static("x-myapp-data"), HeaderValue::from_static(test::black_box("myappdata; excellent")));
-        h.insert(HeaderName::from_static("something"), HeaderValue::from_static(test::black_box("anything")));
+        h.insert(HeaderName::from_static("x-myapp-data"), HeaderValue::from_static(black_box("myappdata; excellent")));
+        h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
     });
 }
 
@@ -111,20 +114,20 @@ use ohkami_benches::response_headers::{
     let mut h = FxMap::new();
     b.iter(|| {
         h
-            .insert("Access-Control-Allow-Credentials", test::black_box("true"))
-            .insert("Access-Control-Allow-Headers", test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-            .insert("Access-Control-Allow-Origin", test::black_box("https://foo.bar.org"))
-            .insert("Access-Control-Max-Age", test::black_box("86400"))
-            .insert("Vary", test::black_box("Origin"))
-            .insert("Server", test::black_box("ohkami"))
-            .insert("Connection", test::black_box("Keep-Alive"))
-            .insert("Date", test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-            .insert("Alt-Svc", test::black_box("h2=\":433\"; ma=2592000"))
-            .insert("Proxy-Authenticate", test::black_box("Basic realm=\"Access to the internal site\""))
-            .insert("Referer-Policy", test::black_box("same-origin"))
-            .insert("X-Frame-Options", test::black_box("DEBY"))
-            .insert("x-myapp-data", test::black_box("myappdata; excellent"))
-            .insert("something", test::black_box("anything"))
+            .insert("Access-Control-Allow-Credentials", black_box("true"))
+            .insert("Access-Control-Allow-Headers", black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+            .insert("Access-Control-Allow-Origin", black_box("https://foo.bar.org"))
+            .insert("Access-Control-Max-Age", black_box("86400"))
+            .insert("Vary", black_box("Origin"))
+            .insert("Server", black_box("ohkami"))
+            .insert("Connection", black_box("Keep-Alive"))
+            .insert("Date", black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+            .insert("Alt-Svc", black_box("h2=\":433\"; ma=2592000"))
+            .insert("Proxy-Authenticate", black_box("Basic realm=\"Access to the internal site\""))
+            .insert("Referer-Policy", black_box("same-origin"))
+            .insert("X-Frame-Options", black_box("DEBY"))
+            .insert("x-myapp-data", black_box("myappdata; excellent"))
+            .insert("something", black_box("anything"))
         ;
     });
 }
@@ -133,20 +136,20 @@ use ohkami_benches::response_headers::{
     let mut h = MyHeaderMap::new();
     b.iter(|| {
         h.set()
-            .AccessControlAllowCredentials(test::black_box("true"))
-            .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-            .AccessControlAllowOrigin(test::black_box("https://foo.bar.org"))
-            .AccessControlMaxAge(test::black_box("86400"))
-            .Vary(test::black_box("Origin"))
-            .Server(test::black_box("ohkami"))
-            .Connection(test::black_box("Keep-Alive"))
-            .Date(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-            .AltSvc(test::black_box("h2=\":433\"; ma=2592000"))
-            .ProxyAuthenticate(test::black_box("Basic realm=\"Access to the internal site\""))
-            .ReferrerPolicy(test::black_box("same-origin"))
-            .XFrameOptions(test::black_box("DEBY"))
-            .custom("x-myapp-data", test::black_box("myappdata; excellent"))
-            .custom("something", test::black_box("anything"))
+            .AccessControlAllowCredentials(black_box("true"))
+            .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+            .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+            .AccessControlMaxAge(black_box("86400"))
+            .Vary(black_box("Origin"))
+            .Server(black_box("ohkami"))
+            .Connection(black_box("Keep-Alive"))
+            .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+            .AltSvc(black_box("h2=\":433\"; ma=2592000"))
+            .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+            .ReferrerPolicy(black_box("same-origin"))
+            .XFrameOptions(black_box("DEBY"))
+            .custom("x-myapp-data", black_box("myappdata; excellent"))
+            .custom("something", black_box("anything"))
         ;
     });
 }
@@ -157,42 +160,42 @@ use ohkami_benches::response_headers::{
 #[bench] fn remove_ohkami(b: &mut test::Bencher) {
     let mut h = ResponseHeaders::_new();
     h.set()
-        .AccessControlAllowCredentials(test::black_box("true"))
-        .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .AccessControlAllowOrigin(test::black_box("https://foo.bar.org"))
-        .AccessControlAllowMethods(test::black_box("POST,GET,OPTIONS,DELETE"))
-        .AccessControlMaxAge(test::black_box("86400"))
-        .Vary(test::black_box("Origin"))
-        .Server(test::black_box("ohkami"))
-        .Connection(test::black_box("Keep-Alive"))
-        .Date(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-        .Via(test::black_box("HTTP/1.1 GWA"))
-        .AltSvc(test::black_box("h2=\":433\"; ma=2592000;"))
-        .ProxyAuthenticate(test::black_box("Basic realm=\"Access to the internal site\""))
-        .ReferrerPolicy(test::black_box("same-origin"))
-        .XFrameOptions(test::black_box("DENY"))
-        .custom("x-myapp-data", test::black_box("myappdata; excellent"))
-        .custom("something", test::black_box("anything"))
+        .AccessControlAllowCredentials(black_box("true"))
+        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+        .AccessControlMaxAge(black_box("86400"))
+        .Vary(black_box("Origin"))
+        .Server(black_box("ohkami"))
+        .Connection(black_box("Keep-Alive"))
+        .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+        .Via(black_box("HTTP/1.1 GWA"))
+        .AltSvc(black_box("h2=\":433\"; ma=2592000;"))
+        .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+        .ReferrerPolicy(black_box("same-origin"))
+        .XFrameOptions(black_box("DENY"))
+        .custom("x-myapp-data", black_box("myappdata; excellent"))
+        .custom("something", black_box("anything"))
     ;
 
     b.iter(|| {
         h.set()
-            .AccessControlAllowCredentials(test::black_box(None))
-            .AccessControlAllowHeaders(test::black_box(None))
-            .AccessControlAllowOrigin(test::black_box(None))
-            .AccessControlAllowMethods(test::black_box(None))
-            .AccessControlMaxAge(test::black_box(None))
-            .Vary(test::black_box(None))
-            .Server(test::black_box(None))
-            .Connection(test::black_box(None))
-            .Date(test::black_box(None))
-            .Via(test::black_box(None))
-            .AltSvc(test::black_box(None))
-            .ProxyAuthenticate(test::black_box(None))
-            .ReferrerPolicy(test::black_box(None))
-            .XFrameOptions(test::black_box(None))
-            .custom("x-myapp-data", test::black_box(None))
-            .custom("something", test::black_box(None))
+            .AccessControlAllowCredentials(black_box(None))
+            .AccessControlAllowHeaders(black_box(None))
+            .AccessControlAllowOrigin(black_box(None))
+            .AccessControlAllowMethods(black_box(None))
+            .AccessControlMaxAge(black_box(None))
+            .Vary(black_box(None))
+            .Server(black_box(None))
+            .Connection(black_box(None))
+            .Date(black_box(None))
+            .Via(black_box(None))
+            .AltSvc(black_box(None))
+            .ProxyAuthenticate(black_box(None))
+            .ReferrerPolicy(black_box(None))
+            .XFrameOptions(black_box(None))
+            .custom("x-myapp-data", black_box(None))
+            .custom("something", black_box(None))
         ;
     });
 }
@@ -200,106 +203,106 @@ use ohkami_benches::response_headers::{
 #[bench] fn remove_heap_ohkami(b: &mut test::Bencher) {
     let mut h = HeapOhkamiHeaders::new();
     h.set()
-        .AccessControlAllowCredentials(test::black_box("true"))
-        .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .AccessControlAllowOrigin(test::black_box("https://foo.bar.org"))
-        .AccessControlAllowMethods(test::black_box("POST,GET,OPTIONS,DELETE"))
-        .AccessControlMaxAge(test::black_box("86400"))
-        .Vary(test::black_box("Origin"))
-        .Server(test::black_box("ohkami"))
-        .Connection(test::black_box("Keep-Alive"))
-        .Date(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-        .Via(test::black_box("HTTP/1.1 GWA"))
-        .AltSvc(test::black_box("h2=\":433\"; ma=2592000;"))
-        .ProxyAuthenticate(test::black_box("Basic realm=\"Access to the internal site\""))
-        .ReferrerPolicy(test::black_box("same-origin"))
-        .XFrameOptions(test::black_box("DENY"))
-        .custom("x-myapp-data", test::black_box("myappdata; excellent"))
-        .custom("something", test::black_box("anything"))
+        .AccessControlAllowCredentials(black_box("true"))
+        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+        .AccessControlMaxAge(black_box("86400"))
+        .Vary(black_box("Origin"))
+        .Server(black_box("ohkami"))
+        .Connection(black_box("Keep-Alive"))
+        .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+        .Via(black_box("HTTP/1.1 GWA"))
+        .AltSvc(black_box("h2=\":433\"; ma=2592000;"))
+        .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+        .ReferrerPolicy(black_box("same-origin"))
+        .XFrameOptions(black_box("DENY"))
+        .custom("x-myapp-data", black_box("myappdata; excellent"))
+        .custom("something", black_box("anything"))
     ;
 
     b.iter(|| {
         h.set()
-            .AccessControlAllowCredentials(test::black_box(None))
-            .AccessControlAllowHeaders(test::black_box(None))
-            .AccessControlAllowOrigin(test::black_box(None))
-            .AccessControlAllowMethods(test::black_box(None))
-            .AccessControlMaxAge(test::black_box(None))
-            .Vary(test::black_box(None))
-            .Server(test::black_box(None))
-            .Connection(test::black_box(None))
-            .Date(test::black_box(None))
-            .Via(test::black_box(None))
-            .AltSvc(test::black_box(None))
-            .ProxyAuthenticate(test::black_box(None))
-            .ReferrerPolicy(test::black_box(None))
-            .XFrameOptions(test::black_box(None))
-            .custom("x-myapp-data", test::black_box(None))
-            .custom("something", test::black_box(None))
+            .AccessControlAllowCredentials(black_box(None))
+            .AccessControlAllowHeaders(black_box(None))
+            .AccessControlAllowOrigin(black_box(None))
+            .AccessControlAllowMethods(black_box(None))
+            .AccessControlMaxAge(black_box(None))
+            .Vary(black_box(None))
+            .Server(black_box(None))
+            .Connection(black_box(None))
+            .Date(black_box(None))
+            .Via(black_box(None))
+            .AltSvc(black_box(None))
+            .ProxyAuthenticate(black_box(None))
+            .ReferrerPolicy(black_box(None))
+            .XFrameOptions(black_box(None))
+            .custom("x-myapp-data", black_box(None))
+            .custom("something", black_box(None))
         ;
     });
 }
 #[bench] fn remove_heap_ohkami_nosize(b: &mut test::Bencher) {
     let mut h = HeapOhkamiHeadersWithoutSize::new();
     h.set()
-        .AccessControlAllowCredentials(test::black_box("true"))
-        .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .AccessControlAllowOrigin(test::black_box("https://foo.bar.org"))
-        .AccessControlAllowMethods(test::black_box("POST,GET,OPTIONS,DELETE"))
-        .AccessControlMaxAge(test::black_box("86400"))
-        .Vary(test::black_box("Origin"))
-        .Server(test::black_box("ohkami"))
-        .Connection(test::black_box("Keep-Alive"))
-        .Date(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-        .Via(test::black_box("HTTP/1.1 GWA"))
-        .AltSvc(test::black_box("h2=\":433\"; ma=2592000;"))
-        .ProxyAuthenticate(test::black_box("Basic realm=\"Access to the internal site\""))
-        .ReferrerPolicy(test::black_box("same-origin"))
-        .XFrameOptions(test::black_box("DENY"))
-        .custom("x-myapp-data", test::black_box("myappdata; excellent"))
-        .custom("something", test::black_box("anything"))
+        .AccessControlAllowCredentials(black_box("true"))
+        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+        .AccessControlMaxAge(black_box("86400"))
+        .Vary(black_box("Origin"))
+        .Server(black_box("ohkami"))
+        .Connection(black_box("Keep-Alive"))
+        .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+        .Via(black_box("HTTP/1.1 GWA"))
+        .AltSvc(black_box("h2=\":433\"; ma=2592000;"))
+        .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+        .ReferrerPolicy(black_box("same-origin"))
+        .XFrameOptions(black_box("DENY"))
+        .custom("x-myapp-data", black_box("myappdata; excellent"))
+        .custom("something", black_box("anything"))
     ;
 
     b.iter(|| {
         h.set()
-            .AccessControlAllowCredentials(test::black_box(None))
-            .AccessControlAllowHeaders(test::black_box(None))
-            .AccessControlAllowOrigin(test::black_box(None))
-            .AccessControlAllowMethods(test::black_box(None))
-            .AccessControlMaxAge(test::black_box(None))
-            .Vary(test::black_box(None))
-            .Server(test::black_box(None))
-            .Connection(test::black_box(None))
-            .Date(test::black_box(None))
-            .Via(test::black_box(None))
-            .AltSvc(test::black_box(None))
-            .ProxyAuthenticate(test::black_box(None))
-            .ReferrerPolicy(test::black_box(None))
-            .XFrameOptions(test::black_box(None))
-            .custom("x-myapp-data", test::black_box(None))
-            .custom("something", test::black_box(None))
+            .AccessControlAllowCredentials(black_box(None))
+            .AccessControlAllowHeaders(black_box(None))
+            .AccessControlAllowOrigin(black_box(None))
+            .AccessControlAllowMethods(black_box(None))
+            .AccessControlMaxAge(black_box(None))
+            .Vary(black_box(None))
+            .Server(black_box(None))
+            .Connection(black_box(None))
+            .Date(black_box(None))
+            .Via(black_box(None))
+            .AltSvc(black_box(None))
+            .ProxyAuthenticate(black_box(None))
+            .ReferrerPolicy(black_box(None))
+            .XFrameOptions(black_box(None))
+            .custom("x-myapp-data", black_box(None))
+            .custom("something", black_box(None))
         ;
     });
 }
 
 #[bench] fn remove_http(b: &mut test::Bencher) {
     let mut h = HeaderMap::new();
-    h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(test::black_box("true")));
-    h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
-    h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(test::black_box("https://foo.bar.org")));
-    h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(test::black_box("POST,GET,OPTIONS,DELETE")));
-    h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(test::black_box("86400")));
-    h.insert(header::VARY, HeaderValue::from_static(test::black_box("Origin")));
-    h.insert(header::SERVER, HeaderValue::from_static(test::black_box("ohkami")));
-    h.insert(header::CONNECTION, HeaderValue::from_static(test::black_box("Keep-Alive")));
-    h.insert(header::DATE, HeaderValue::from_static(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT")));
-    h.insert(header::VIA, HeaderValue::from_static(test::black_box("HTTP/1.1 GWA")));
-    h.insert(header::ALT_SVC, HeaderValue::from_static(test::black_box("h2=\":433\"; ma=2592000;")));
-    h.insert(header::PROXY_AUTHENTICATE, HeaderValue::from_static(test::black_box("Basic realm=\"Access to the internal site\"")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(black_box("true")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(black_box("https://foo.bar.org")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(black_box("POST,GET,OPTIONS,DELETE")));
+    h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(black_box("86400")));
+    h.insert(header::VARY, HeaderValue::from_static(black_box("Origin")));
+    h.insert(header::SERVER, HeaderValue::from_static(black_box("ohkami")));
+    h.insert(header::CONNECTION, HeaderValue::from_static(black_box("Keep-Alive")));
+    h.insert(header::DATE, HeaderValue::from_static(black_box("Wed, 21 Oct 2015 07:28:00 GMT")));
+    h.insert(header::VIA, HeaderValue::from_static(black_box("HTTP/1.1 GWA")));
+    h.insert(header::ALT_SVC, HeaderValue::from_static(black_box("h2=\":433\"; ma=2592000;")));
+    h.insert(header::PROXY_AUTHENTICATE, HeaderValue::from_static(black_box("Basic realm=\"Access to the internal site\"")));
     h.insert(header::REFERRER_POLICY, HeaderValue::from_static("same-origin"));
     h.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
-    h.insert(HeaderName::from_static("x-myapp-data"), HeaderValue::from_static(test::black_box("myappdata; excellent")));
-    h.insert(HeaderName::from_static("something"), HeaderValue::from_static(test::black_box("anything")));
+    h.insert(HeaderName::from_static("x-myapp-data"), HeaderValue::from_static(black_box("myappdata; excellent")));
+    h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
 
     b.iter(|| {
         h.remove(header::ACCESS_CONTROL_ALLOW_CREDENTIALS);
@@ -324,20 +327,20 @@ use ohkami_benches::response_headers::{
 #[bench] fn remove_fxmap(b: &mut test::Bencher) {
     let mut h = FxMap::new();
     h
-        .insert("Access-Control-Allow-Credentials", test::black_box("true"))
-        .insert("Access-Control-Allow-Headers", test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .insert("Access-Control-Allow-Origin", test::black_box("https://foo.bar.org"))
-        .insert("Access-Control-Max-Age", test::black_box("86400"))
-        .insert("Vary", test::black_box("Origin"))
-        .insert("Server", test::black_box("ohkami"))
-        .insert("Connection", test::black_box("Keep-Alive"))
-        .insert("Date", test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-        .insert("Alt-Svc", test::black_box("h2=\":433\"; ma=2592000"))
-        .insert("Proxy-Authenticate", test::black_box("Basic realm=\"Access to the internal site\""))
-        .insert("Referer-Policy", test::black_box("same-origin"))
-        .insert("X-Frame-Options", test::black_box("DEBY"))
-        .insert("x-myapp-data", test::black_box("myappdata; excellent"))
-        .insert("something", test::black_box("anything"))
+        .insert("Access-Control-Allow-Credentials", black_box("true"))
+        .insert("Access-Control-Allow-Headers", black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .insert("Access-Control-Allow-Origin", black_box("https://foo.bar.org"))
+        .insert("Access-Control-Max-Age", black_box("86400"))
+        .insert("Vary", black_box("Origin"))
+        .insert("Server", black_box("ohkami"))
+        .insert("Connection", black_box("Keep-Alive"))
+        .insert("Date", black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+        .insert("Alt-Svc", black_box("h2=\":433\"; ma=2592000"))
+        .insert("Proxy-Authenticate", black_box("Basic realm=\"Access to the internal site\""))
+        .insert("Referer-Policy", black_box("same-origin"))
+        .insert("X-Frame-Options", black_box("DEBY"))
+        .insert("x-myapp-data", black_box("myappdata; excellent"))
+        .insert("something", black_box("anything"))
     ;
 
     b.iter(|| {
@@ -364,40 +367,40 @@ use ohkami_benches::response_headers::{
     let mut h = MyHeaderMap::new();
     
     h.set()
-        .AccessControlAllowCredentials(test::black_box("true"))
-        .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .AccessControlAllowOrigin(test::black_box("https://foo.bar.org"))
-        .AccessControlMaxAge(test::black_box("86400"))
-        .Vary(test::black_box("Origin"))
-        .Server(test::black_box("ohkami"))
-        .Connection(test::black_box("Keep-Alive"))
-        .Date(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-        .AltSvc(test::black_box("h2=\":433\"; ma=2592000"))
-        .ProxyAuthenticate(test::black_box("Basic realm=\"Access to the internal site\""))
-        .ReferrerPolicy(test::black_box("same-origin"))
-        .XFrameOptions(test::black_box("DEBY"))
-        .custom("x-myapp-data", test::black_box("myappdata; excellent"))
-        .custom("something", test::black_box("anything"))
+        .AccessControlAllowCredentials(black_box("true"))
+        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        .AccessControlMaxAge(black_box("86400"))
+        .Vary(black_box("Origin"))
+        .Server(black_box("ohkami"))
+        .Connection(black_box("Keep-Alive"))
+        .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+        .AltSvc(black_box("h2=\":433\"; ma=2592000"))
+        .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+        .ReferrerPolicy(black_box("same-origin"))
+        .XFrameOptions(black_box("DEBY"))
+        .custom("x-myapp-data", black_box("myappdata; excellent"))
+        .custom("something", black_box("anything"))
     ;
 
     b.iter(|| {
         h.set()
-            .AccessControlAllowCredentials(test::black_box(None))
-            .AccessControlAllowHeaders(test::black_box(None))
-            .AccessControlAllowOrigin(test::black_box(None))
-            .AccessControlAllowMethods(test::black_box(None))
-            .AccessControlMaxAge(test::black_box(None))
-            .Vary(test::black_box(None))
-            .Server(test::black_box(None))
-            .Connection(test::black_box(None))
-            .Date(test::black_box(None))
-            .Via(test::black_box(None))
-            .AltSvc(test::black_box(None))
-            .ProxyAuthenticate(test::black_box(None))
-            .ReferrerPolicy(test::black_box(None))
-            .XFrameOptions(test::black_box(None))
-            .custom("x-myapp-data", test::black_box(None))
-            .custom("something", test::black_box(None))
+            .AccessControlAllowCredentials(black_box(None))
+            .AccessControlAllowHeaders(black_box(None))
+            .AccessControlAllowOrigin(black_box(None))
+            .AccessControlAllowMethods(black_box(None))
+            .AccessControlMaxAge(black_box(None))
+            .Vary(black_box(None))
+            .Server(black_box(None))
+            .Connection(black_box(None))
+            .Date(black_box(None))
+            .Via(black_box(None))
+            .AltSvc(black_box(None))
+            .ProxyAuthenticate(black_box(None))
+            .ReferrerPolicy(black_box(None))
+            .XFrameOptions(black_box(None))
+            .custom("x-myapp-data", black_box(None))
+            .custom("something", black_box(None))
         ;
     });
 }
@@ -408,22 +411,22 @@ use ohkami_benches::response_headers::{
 #[bench] fn write_ohkami(b: &mut test::Bencher) {
     let mut h = ResponseHeaders::_new();
     h.set()
-        .AccessControlAllowCredentials(test::black_box("true"))
-        .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .AccessControlAllowOrigin(test::black_box("https://foo.bar.org"))
-        .AccessControlAllowMethods(test::black_box("POST,GET,OPTIONS,DELETE"))
-        .AccessControlMaxAge(test::black_box("86400"))
-        .Vary(test::black_box("Origin"))
-        .Server(test::black_box("ohkami"))
-        .Connection(test::black_box("Keep-Alive"))
-        .Date(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-        .Via(test::black_box("HTTP/1.1 GWA"))
-        .AltSvc(test::black_box("h2=\":433\"; ma=2592000;"))
-        .ProxyAuthenticate(test::black_box("Basic realm=\"Access to the internal site\""))
-        .ReferrerPolicy(test::black_box("same-origin"))
-        .XFrameOptions(test::black_box("DENY"))
-        .custom("x-myapp-data", test::black_box("myappdata; excellent"))
-        .custom("something", test::black_box("anything"))
+        .AccessControlAllowCredentials(black_box("true"))
+        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+        .AccessControlMaxAge(black_box("86400"))
+        .Vary(black_box("Origin"))
+        .Server(black_box("ohkami"))
+        .Connection(black_box("Keep-Alive"))
+        .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+        .Via(black_box("HTTP/1.1 GWA"))
+        .AltSvc(black_box("h2=\":433\"; ma=2592000;"))
+        .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+        .ReferrerPolicy(black_box("same-origin"))
+        .XFrameOptions(black_box("DENY"))
+        .custom("x-myapp-data", black_box("myappdata; excellent"))
+        .custom("something", black_box("anything"))
     ;
 
     let mut buf = Vec::new();
@@ -435,22 +438,22 @@ use ohkami_benches::response_headers::{
 #[bench] fn write_heap_ohkami(b: &mut test::Bencher) {
     let mut h = HeapOhkamiHeaders::new();
     h.set()
-        .AccessControlAllowCredentials(test::black_box("true"))
-        .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .AccessControlAllowOrigin(test::black_box("https://foo.bar.org"))
-        .AccessControlAllowMethods(test::black_box("POST,GET,OPTIONS,DELETE"))
-        .AccessControlMaxAge(test::black_box("86400"))
-        .Vary(test::black_box("Origin"))
-        .Server(test::black_box("ohkami"))
-        .Connection(test::black_box("Keep-Alive"))
-        .Date(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-        .Via(test::black_box("HTTP/1.1 GWA"))
-        .AltSvc(test::black_box("h2=\":433\"; ma=2592000;"))
-        .ProxyAuthenticate(test::black_box("Basic realm=\"Access to the internal site\""))
-        .ReferrerPolicy(test::black_box("same-origin"))
-        .XFrameOptions(test::black_box("DENY"))
-        .custom("x-myapp-data", test::black_box("myappdata; excellent"))
-        .custom("something", test::black_box("anything"))
+        .AccessControlAllowCredentials(black_box("true"))
+        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+        .AccessControlMaxAge(black_box("86400"))
+        .Vary(black_box("Origin"))
+        .Server(black_box("ohkami"))
+        .Connection(black_box("Keep-Alive"))
+        .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+        .Via(black_box("HTTP/1.1 GWA"))
+        .AltSvc(black_box("h2=\":433\"; ma=2592000;"))
+        .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+        .ReferrerPolicy(black_box("same-origin"))
+        .XFrameOptions(black_box("DENY"))
+        .custom("x-myapp-data", black_box("myappdata; excellent"))
+        .custom("something", black_box("anything"))
     ;
 
     let mut buf = Vec::new();
@@ -461,22 +464,22 @@ use ohkami_benches::response_headers::{
 #[bench] fn write_heap_ohkami_only_standards(b: &mut test::Bencher) {
     let mut h = HeapOhkamiHeaders::new();
     h.set()
-        .AccessControlAllowCredentials(test::black_box("true"))
-        .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .AccessControlAllowOrigin(test::black_box("https://foo.bar.org"))
-        .AccessControlAllowMethods(test::black_box("POST,GET,OPTIONS,DELETE"))
-        .AccessControlMaxAge(test::black_box("86400"))
-        .Vary(test::black_box("Origin"))
-        .Server(test::black_box("ohkami"))
-        .Connection(test::black_box("Keep-Alive"))
-        .Date(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-        .Via(test::black_box("HTTP/1.1 GWA"))
-        .AltSvc(test::black_box("h2=\":433\"; ma=2592000;"))
-        .ProxyAuthenticate(test::black_box("Basic realm=\"Access to the internal site\""))
-        .ReferrerPolicy(test::black_box("same-origin"))
-        .XFrameOptions(test::black_box("DENY"))
-        .custom("x-myapp-data", test::black_box("myappdata; excellent"))
-        .custom("something", test::black_box("anything"))
+        .AccessControlAllowCredentials(black_box("true"))
+        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+        .AccessControlMaxAge(black_box("86400"))
+        .Vary(black_box("Origin"))
+        .Server(black_box("ohkami"))
+        .Connection(black_box("Keep-Alive"))
+        .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+        .Via(black_box("HTTP/1.1 GWA"))
+        .AltSvc(black_box("h2=\":433\"; ma=2592000;"))
+        .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+        .ReferrerPolicy(black_box("same-origin"))
+        .XFrameOptions(black_box("DENY"))
+        .custom("x-myapp-data", black_box("myappdata; excellent"))
+        .custom("something", black_box("anything"))
     ;
 
     let mut buf = Vec::new();
@@ -486,22 +489,22 @@ use ohkami_benches::response_headers::{
 }#[bench] fn write_heap_ohkami_nosize(b: &mut test::Bencher) {
     let mut h = HeapOhkamiHeadersWithoutSize::new();
     h.set()
-        .AccessControlAllowCredentials(test::black_box("true"))
-        .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .AccessControlAllowOrigin(test::black_box("https://foo.bar.org"))
-        .AccessControlAllowMethods(test::black_box("POST,GET,OPTIONS,DELETE"))
-        .AccessControlMaxAge(test::black_box("86400"))
-        .Vary(test::black_box("Origin"))
-        .Server(test::black_box("ohkami"))
-        .Connection(test::black_box("Keep-Alive"))
-        .Date(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-        .Via(test::black_box("HTTP/1.1 GWA"))
-        .AltSvc(test::black_box("h2=\":433\"; ma=2592000;"))
-        .ProxyAuthenticate(test::black_box("Basic realm=\"Access to the internal site\""))
-        .ReferrerPolicy(test::black_box("same-origin"))
-        .XFrameOptions(test::black_box("DENY"))
-        .custom("x-myapp-data", test::black_box("myappdata; excellent"))
-        .custom("something", test::black_box("anything"))
+        .AccessControlAllowCredentials(black_box("true"))
+        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+        .AccessControlMaxAge(black_box("86400"))
+        .Vary(black_box("Origin"))
+        .Server(black_box("ohkami"))
+        .Connection(black_box("Keep-Alive"))
+        .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+        .Via(black_box("HTTP/1.1 GWA"))
+        .AltSvc(black_box("h2=\":433\"; ma=2592000;"))
+        .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+        .ReferrerPolicy(black_box("same-origin"))
+        .XFrameOptions(black_box("DENY"))
+        .custom("x-myapp-data", black_box("myappdata; excellent"))
+        .custom("something", black_box("anything"))
     ;
 
     let mut buf = Vec::new();
@@ -512,22 +515,22 @@ use ohkami_benches::response_headers::{
 #[bench] fn write_heap_ohkami_only_standards_nosize(b: &mut test::Bencher) {
     let mut h = HeapOhkamiHeadersWithoutSize::new();
     h.set()
-        .AccessControlAllowCredentials(test::black_box("true"))
-        .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .AccessControlAllowOrigin(test::black_box("https://foo.bar.org"))
-        .AccessControlAllowMethods(test::black_box("POST,GET,OPTIONS,DELETE"))
-        .AccessControlMaxAge(test::black_box("86400"))
-        .Vary(test::black_box("Origin"))
-        .Server(test::black_box("ohkami"))
-        .Connection(test::black_box("Keep-Alive"))
-        .Date(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-        .Via(test::black_box("HTTP/1.1 GWA"))
-        .AltSvc(test::black_box("h2=\":433\"; ma=2592000;"))
-        .ProxyAuthenticate(test::black_box("Basic realm=\"Access to the internal site\""))
-        .ReferrerPolicy(test::black_box("same-origin"))
-        .XFrameOptions(test::black_box("DENY"))
-        .custom("x-myapp-data", test::black_box("myappdata; excellent"))
-        .custom("something", test::black_box("anything"))
+        .AccessControlAllowCredentials(black_box("true"))
+        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+        .AccessControlMaxAge(black_box("86400"))
+        .Vary(black_box("Origin"))
+        .Server(black_box("ohkami"))
+        .Connection(black_box("Keep-Alive"))
+        .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+        .Via(black_box("HTTP/1.1 GWA"))
+        .AltSvc(black_box("h2=\":433\"; ma=2592000;"))
+        .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+        .ReferrerPolicy(black_box("same-origin"))
+        .XFrameOptions(black_box("DENY"))
+        .custom("x-myapp-data", black_box("myappdata; excellent"))
+        .custom("something", black_box("anything"))
     ;
 
     let mut buf = Vec::new();
@@ -538,22 +541,22 @@ use ohkami_benches::response_headers::{
 
 #[bench] fn write_http(b: &mut test::Bencher) {
     let mut h = HeaderMap::new();
-    h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(test::black_box("true")));
-    h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
-    h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(test::black_box("https://foo.bar.org")));
-    h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(test::black_box("POST,GET,OPTIONS,DELETE")));
-    h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(test::black_box("86400")));
-    h.insert(header::VARY, HeaderValue::from_static(test::black_box("Origin")));
-    h.insert(header::SERVER, HeaderValue::from_static(test::black_box("ohkami")));
-    h.insert(header::CONNECTION, HeaderValue::from_static(test::black_box("Keep-Alive")));
-    h.insert(header::DATE, HeaderValue::from_static(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT")));
-    h.insert(header::VIA, HeaderValue::from_static(test::black_box("HTTP/1.1 GWA")));
-    h.insert(header::ALT_SVC, HeaderValue::from_static(test::black_box("h2=\":433\"; ma=2592000;")));
-    h.insert(header::PROXY_AUTHENTICATE, HeaderValue::from_static(test::black_box("Basic realm=\"Access to the internal site\"")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(black_box("true")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(black_box("https://foo.bar.org")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(black_box("POST,GET,OPTIONS,DELETE")));
+    h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(black_box("86400")));
+    h.insert(header::VARY, HeaderValue::from_static(black_box("Origin")));
+    h.insert(header::SERVER, HeaderValue::from_static(black_box("ohkami")));
+    h.insert(header::CONNECTION, HeaderValue::from_static(black_box("Keep-Alive")));
+    h.insert(header::DATE, HeaderValue::from_static(black_box("Wed, 21 Oct 2015 07:28:00 GMT")));
+    h.insert(header::VIA, HeaderValue::from_static(black_box("HTTP/1.1 GWA")));
+    h.insert(header::ALT_SVC, HeaderValue::from_static(black_box("h2=\":433\"; ma=2592000;")));
+    h.insert(header::PROXY_AUTHENTICATE, HeaderValue::from_static(black_box("Basic realm=\"Access to the internal site\"")));
     h.insert(header::REFERRER_POLICY, HeaderValue::from_static("same-origin"));
     h.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
-    h.insert(HeaderName::from_static("x-myapp-data"), HeaderValue::from_static(test::black_box("myappdata; excellent")));
-    h.insert(HeaderName::from_static("something"), HeaderValue::from_static(test::black_box("anything")));
+    h.insert(HeaderName::from_static("x-myapp-data"), HeaderValue::from_static(black_box("myappdata; excellent")));
+    h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
 
     let mut buf = Vec::new();
     b.iter(|| {
@@ -570,20 +573,20 @@ use ohkami_benches::response_headers::{
 #[bench] fn write_fxmap(b: &mut test::Bencher) {
     let mut h = FxMap::new();
     h
-        .insert("Access-Control-Allow-Credentials", test::black_box("true"))
-        .insert("Access-Control-Allow-Headers", test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .insert("Access-Control-Allow-Origin", test::black_box("https://foo.bar.org"))
-        .insert("Access-Control-Max-Age", test::black_box("86400"))
-        .insert("Vary", test::black_box("Origin"))
-        .insert("Server", test::black_box("ohkami"))
-        .insert("Connection", test::black_box("Keep-Alive"))
-        .insert("Date", test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-        .insert("Alt-Svc", test::black_box("h2=\":433\"; ma=2592000"))
-        .insert("Proxy-Authenticate", test::black_box("Basic realm=\"Access to the internal site\""))
-        .insert("Referer-Policy", test::black_box("same-origin"))
-        .insert("X-Frame-Options", test::black_box("DEBY"))
-        .insert("x-myapp-data", test::black_box("myappdata; excellent"))
-        .insert("something", test::black_box("anything"))
+        .insert("Access-Control-Allow-Credentials", black_box("true"))
+        .insert("Access-Control-Allow-Headers", black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .insert("Access-Control-Allow-Origin", black_box("https://foo.bar.org"))
+        .insert("Access-Control-Max-Age", black_box("86400"))
+        .insert("Vary", black_box("Origin"))
+        .insert("Server", black_box("ohkami"))
+        .insert("Connection", black_box("Keep-Alive"))
+        .insert("Date", black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+        .insert("Alt-Svc", black_box("h2=\":433\"; ma=2592000"))
+        .insert("Proxy-Authenticate", black_box("Basic realm=\"Access to the internal site\""))
+        .insert("Referer-Policy", black_box("same-origin"))
+        .insert("X-Frame-Options", black_box("DEBY"))
+        .insert("x-myapp-data", black_box("myappdata; excellent"))
+        .insert("something", black_box("anything"))
     ;
 
     let mut buf = Vec::new();
@@ -595,20 +598,20 @@ use ohkami_benches::response_headers::{
 #[bench] fn write_headermap(b: &mut test::Bencher) {
     let mut h = MyHeaderMap::new();
     h.set()
-        .AccessControlAllowCredentials(test::black_box("true"))
-        .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .AccessControlAllowOrigin(test::black_box("https://foo.bar.org"))
-        .AccessControlMaxAge(test::black_box("86400"))
-        .Vary(test::black_box("Origin"))
-        .Server(test::black_box("ohkami"))
-        .Connection(test::black_box("Keep-Alive"))
-        .Date(test::black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
-        .AltSvc(test::black_box("h2=\":433\"; ma=2592000"))
-        .ProxyAuthenticate(test::black_box("Basic realm=\"Access to the internal site\""))
-        .ReferrerPolicy(test::black_box("same-origin"))
-        .XFrameOptions(test::black_box("DEBY"))
-        .custom("x-myapp-data", test::black_box("myappdata; excellent"))
-        .custom("something", test::black_box("anything"))
+        .AccessControlAllowCredentials(black_box("true"))
+        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        .AccessControlMaxAge(black_box("86400"))
+        .Vary(black_box("Origin"))
+        .Server(black_box("ohkami"))
+        .Connection(black_box("Keep-Alive"))
+        .Date(black_box("Wed, 21 Oct 2015 07:28:00 GMT"))
+        .AltSvc(black_box("h2=\":433\"; ma=2592000"))
+        .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
+        .ReferrerPolicy(black_box("same-origin"))
+        .XFrameOptions(black_box("DEBY"))
+        .custom("x-myapp-data", black_box("myappdata; excellent"))
+        .custom("something", black_box("anything"))
     ;
 
     let mut buf = Vec::new();

--- a/benches/benches/response_headers.rs
+++ b/benches/benches/response_headers.rs
@@ -15,7 +15,7 @@ use ohkami_benches::response_headers::{
 
 
 #[bench] fn insert_ohkami(b: &mut test::Bencher) {
-    let mut h = ResponseHeaders::init();
+    let mut h = ResponseHeaders::_new();
     b.iter(|| {
         h.set()
             .AccessControlAllowCredentials(test::black_box("true"))
@@ -155,7 +155,7 @@ use ohkami_benches::response_headers::{
 
 
 #[bench] fn remove_ohkami(b: &mut test::Bencher) {
-    let mut h = ResponseHeaders::init();
+    let mut h = ResponseHeaders::_new();
     h.set()
         .AccessControlAllowCredentials(test::black_box("true"))
         .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
@@ -406,7 +406,7 @@ use ohkami_benches::response_headers::{
 
 
 #[bench] fn write_ohkami(b: &mut test::Bencher) {
-    let mut h = ResponseHeaders::init();
+    let mut h = ResponseHeaders::_new();
     h.set()
         .AccessControlAllowCredentials(test::black_box("true"))
         .AccessControlAllowHeaders(test::black_box("X-Custom-Header,Upgrade-Insecure-Requests"))

--- a/benches/src/bin/hello.rs
+++ b/benches/src/bin/hello.rs
@@ -1,0 +1,46 @@
+use ohkami::prelude::*;
+use ohkami::{typed::Payload, builtin::payload::JSON};
+
+struct Logger;
+const _: () = {
+    impl<I: FangProc> Fang<I> for Logger {
+        type Proc = LoggerProc<I>;
+        fn chain(&self, inner: I) -> Self::Proc {
+            LoggerProc { inner }
+        }
+    }
+
+    struct LoggerProc<I: FangProc> {
+        inner: I
+    }
+    impl<I: FangProc> FangProc for LoggerProc<I> {
+        async fn bite<'b>(&'b self, req: &'b mut Request) -> Response {
+            tracing::info!("\n{req:?}");
+            let res = self.inner.bite(req).await;
+            tracing::info!("\n{res:?}");
+            res
+        }
+    }
+};
+
+#[Payload(JSON/S)]
+struct Message {
+    message: String
+}
+
+async fn hello(name: &str) -> Message {
+    Message {
+        message: format!("Hello, {name}!")
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    Ohkami::with(Logger, (
+        "/hello/:name".GET(hello),
+    )).howl("localhost:3000").await
+}

--- a/benches/src/response_headers/heap_ohkami_headers.rs
+++ b/benches/src/response_headers/heap_ohkami_headers.rs
@@ -227,6 +227,7 @@ macro_rules! Header {
 
 
 impl HeapOhkamiHeaders {
+    #[inline]
     fn insert(&mut self, key: Header, value: impl Into<Cow<'static, str>>) {
         let value = value.into();
         let (name_len, value_len) = (key.as_bytes().len(), value.len());
@@ -243,11 +244,12 @@ impl HeapOhkamiHeaders {
         }
     }
 
+    #[inline]
     fn remove(&mut self, key: Header) {
         let key_size = key.as_bytes().len();
         let v = unsafe {self.standard.get_unchecked_mut(key as usize)};
         if let Some(v) = v.take() {
-            self.size -= key_size + 2/* ": ".len()*/ + v.len() + 2/*"\r\n".len()*/
+            self.size -= key_size + ": ".len() + v.len() + "\r\n".len()
         }
     }
 

--- a/benches/src/response_headers/heap_ohkami_headers_nosize.rs
+++ b/benches/src/response_headers/heap_ohkami_headers_nosize.rs
@@ -210,10 +210,12 @@ macro_rules! Header {
 
 
 impl HeapOhkamiHeadersWithoutSize {
+    #[inline]
     fn insert(&mut self, key: Header, value: impl Into<Cow<'static, str>>) {
         unsafe {*self.standard.get_unchecked_mut(key as usize) = Some(value.into())}
     }
 
+    #[inline]
     fn remove(&mut self, key: Header) {
         unsafe {*self.standard.get_unchecked_mut(key as usize) = None}
     }

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -53,7 +53,7 @@ DEBUG = [
 #default = [
 #    "testing",
 #    #"websocket",
-#    #"rt_tokio",
-#    "rt_async-std",
+#    "rt_tokio",
+#    #"rt_async-std",
 #    "DEBUG",
 #]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -28,10 +28,11 @@ byte_reader   = { workspace = true }
 serde         = { workspace = true }
 
 serde_json    = { version = "1.0" }
-#sha1         = { version = "0.10.6", optional = true, default-features = false }
-sha2          = { version = "0.10.8", default-features = false }
+rustc-hash    = { version = "1.1" }
+
 hmac          = { version = "0.12.1", default-features = false }
-rustc-hash    = { version = "1.1", optional = true }
+sha2          = { version = "0.10.8", default-features = false }
+#sha1         = { version = "0.10.6", optional = true, default-features = false }
 
 
 [features]
@@ -40,7 +41,6 @@ rt_tokio      = ["dep:tokio"]
 rt_async-std  = ["dep:async-std"]
 nightly       = []
 testing       = []
-custom-header = ["dep:rustc-hash"]
 #websocket    = ["dep:sha1"]
 #sse          = []
 
@@ -52,7 +52,6 @@ DEBUG = [
 ]
 #default = [
 #    "testing",
-#    "custom-header",
 #    #"websocket",
 #    #"rt_tokio",
 #    "rt_async-std",

--- a/ohkami/src/request/headers.rs
+++ b/ohkami/src/request/headers.rs
@@ -2,19 +2,13 @@ use std::borrow::Cow;
 use crate::__internal__::Append;
 use ohkami_lib::{CowSlice, Slice};
 
-#[cfg(feature="custom-header")]
 use rustc_hash::FxHashMap;
 
 
 pub struct Headers {
-    values: [Option<CowSlice>; N_CLIENT_HEADERS],
-
-    #[cfg(feature="custom-header")]
-    custom: Option<Box<CustomHeaderMap>>,
+    standard: Box<[Option<CowSlice>; N_CLIENT_HEADERS]>,
+    custom:   Option<Box<FxHashMap<CowSlice, CowSlice>>>,
 }
-
-#[cfg(feature="custom-header")]
-type CustomHeaderMap = FxHashMap<CowSlice, CowSlice>;
 
 pub struct SetHeaders<'set>(
     &'set mut Headers
@@ -25,134 +19,104 @@ pub struct SetHeaders<'set>(
 }
 
 pub trait HeaderAction<'set> {
-    fn perform(self, set_headers: SetHeaders<'set>, key: Header) -> SetHeaders<'set>;
+    fn perform(self, set: SetHeaders<'set>, key: Header) -> SetHeaders<'set>;
 } const _: () = {
     // remove
     impl<'set> HeaderAction<'set> for Option<()> {
-        fn perform(self, set_headers: SetHeaders<'set>, key: Header) -> SetHeaders<'set> {
-            set_headers.0.remove(key);
-            set_headers
+        fn perform(self, set: SetHeaders<'set>, key: Header) -> SetHeaders<'set> {
+            set.0.remove(key);
+            set
         }
     }
 
     // append
     impl<'set> HeaderAction<'set> for Append {
-        fn perform(self, set_headers: SetHeaders<'set>, key: Header) -> SetHeaders<'set> {
-            set_headers.0.append(key, self.0);
-            set_headers
+        fn perform(self, set: SetHeaders<'set>, key: Header) -> SetHeaders<'set> {
+            set.0.append(key, self.0);
+            set
         }
     }
 
     // insert
     impl<'set> HeaderAction<'set> for &'static str {
-        #[inline] fn perform(self, set_headers: SetHeaders<'set>, key: Header) -> SetHeaders<'set> {
-            set_headers.0.insert(key, CowSlice::Ref(unsafe {Slice::from_bytes(self.as_bytes())}));
-            set_headers
+        #[inline] fn perform(self, set: SetHeaders<'set>, key: Header) -> SetHeaders<'set> {
+            set.0.insert(key, CowSlice::Ref(unsafe {Slice::from_bytes(self.as_bytes())}));
+            set
         }
     }
     impl<'set> HeaderAction<'set> for String {
-        #[inline] fn perform(self, set_headers: SetHeaders<'set>, key: Header) -> SetHeaders<'set> {
-            set_headers.0.insert(key, CowSlice::Own(self.into_bytes()));
-            set_headers
+        #[inline] fn perform(self, set: SetHeaders<'set>, key: Header) -> SetHeaders<'set> {
+            set.0.insert(key, CowSlice::Own(self.into_bytes()));
+            set
         }
     }
     impl<'set> HeaderAction<'set> for std::borrow::Cow<'static, str> {
-        fn perform(self, set_headers: SetHeaders<'set>, key: Header) -> SetHeaders<'set> {
-            set_headers.0.insert(key, CowSlice::Ref(unsafe {Slice::from_bytes(self.as_bytes())}));
-            set_headers
+        fn perform(self, set: SetHeaders<'set>, key: Header) -> SetHeaders<'set> {
+            set.0.insert(key, CowSlice::Ref(unsafe {Slice::from_bytes(self.as_bytes())}));
+            set
         }
     }
 };
 
-#[cfg(feature="custom-header")]
 pub trait CustomHeadersAction<'set> {
-    fn perform(self, set_headers: SetHeaders<'set>, key: impl Into<Cow<'static, str>>) -> SetHeaders<'set>;
+    fn perform(self, set: SetHeaders<'set>, key: impl Into<Cow<'static, str>>) -> SetHeaders<'set>;
 }
-#[cfg(feature="custom-header")]
 const _: () = {
     // remove
     impl<'set> CustomHeadersAction<'set> for Option<()> {
-        fn perform(self, set_headers: SetHeaders<'set>, key: impl Into<Cow<'static, str>>) -> SetHeaders<'set> {
-            if let Some(c) = &mut set_headers.0.custom {
+        fn perform(self, set: SetHeaders<'set>, key: impl Into<Cow<'static, str>>) -> SetHeaders<'set> {
+            if let Some(c) = &mut set.0.custom {
                 c.remove(&CowSlice::from(key.into()));
             }
-            set_headers
+            set
         }
     }
 
     // append
     impl<'set> CustomHeadersAction<'set> for Append {
-        fn perform(self, set_headers: SetHeaders<'set>, key: impl Into<Cow<'static, str>>) -> SetHeaders<'set> {
+        fn perform(self, set: SetHeaders<'set>, key: impl Into<Cow<'static, str>>) -> SetHeaders<'set> {
             let key = CowSlice::from(key.into());
+            let custom = set.0.get_or_init_custom_mut();
 
-            if let Some(c) = &mut set_headers.0.custom {
-                if let Some(value) = c.get_mut(&key) {
-                    unsafe {value.extend(b",")}
-                    unsafe {value.extend(self.0.as_bytes())}
-                } else {
-                    c.insert(key, CowSlice::from(self.0));
+            if let Some(value) = custom.get_mut(&key) {
+                unsafe {
+                    value.extend(b",");
+                    value.extend(self.0.as_bytes());
                 }
             } else {
-                set_headers.0.custom = Some(Box::new(CustomHeaderMap::from_iter([(
-                    CowSlice::from(key),
-                    CowSlice::from(self.0)
-                )])))
+                custom.insert(key, CowSlice::from(self.0));
             }
 
-            set_headers
+            set
         }
     }
 
     // insert
     impl<'set> CustomHeadersAction<'set> for &'static str {
-        fn perform(self, set_headers: SetHeaders<'set>, key: impl Into<Cow<'static, str>>) -> SetHeaders<'set> {
-            match &mut set_headers.0.custom {
-                None => set_headers.0.custom = Some(Box::new(
-                    CustomHeaderMap::from_iter([(
-                        CowSlice::from(key.into()),
-                        CowSlice::Ref(unsafe {Slice::from_bytes(self.as_bytes())})
-                    )])
-                )),
-                Some(c) => {c.insert(
-                    CowSlice::from(key.into()),
-                    CowSlice::Ref(unsafe {Slice::from_bytes(self.as_bytes())})
-                );}
-            }
-            set_headers
+        fn perform(self, set: SetHeaders<'set>, key: impl Into<Cow<'static, str>>) -> SetHeaders<'set> {
+            set.0.get_or_init_custom_mut().insert(
+                CowSlice::from(key.into()),
+                CowSlice::Ref(unsafe {Slice::from_bytes(self.as_bytes())})
+            );
+            set
         }
     }
     impl<'set> CustomHeadersAction<'set> for String {
-        fn perform(self, set_headers: SetHeaders<'set>, key: impl Into<Cow<'static, str>>) -> SetHeaders<'set> {
-            match &mut set_headers.0.custom {
-                None => set_headers.0.custom = Some(Box::new(
-                    CustomHeaderMap::from_iter([(
-                        CowSlice::from(key.into()),
-                        CowSlice::Own(self.into_bytes())
-                    )])
-                )),
-                Some(c) => {c.insert(
-                    CowSlice::from(key.into()),
-                    CowSlice::Own(self.into_bytes())
-                );}
-            }
-            set_headers
+        fn perform(self, set: SetHeaders<'set>, key: impl Into<Cow<'static, str>>) -> SetHeaders<'set> {
+            set.0.get_or_init_custom_mut().insert(
+                CowSlice::from(key.into()),
+                CowSlice::Own(self.into_bytes())
+            );
+            set
         }
     }
     impl<'set> CustomHeadersAction<'set> for Cow<'static, str> {
-        fn perform(self, set_headers: SetHeaders<'set>, key: impl Into<Cow<'static, str>>) -> SetHeaders<'set> {
-            match &mut set_headers.0.custom {
-                None => set_headers.0.custom = Some(Box::new(
-                    CustomHeaderMap::from_iter([(
-                        CowSlice::from(key.into()),
-                        CowSlice::from(self)
-                    )])
-                )),
-                Some(c) => {c.insert(
-                    CowSlice::from(key.into()),
-                    CowSlice::from(self)
-                );}
-            }
-            set_headers
+        fn perform(self, set: SetHeaders<'set>, key: impl Into<Cow<'static, str>>) -> SetHeaders<'set> {
+            set.0.get_or_init_custom_mut().insert(
+                CowSlice::from(key.into()),
+                CowSlice::from(self)
+            );
+            set
         }
     }
 };
@@ -199,11 +163,9 @@ macro_rules! Header {
                 }
             )*
 
-            #[cfg(feature="custom-header")]
-            /// **`custom-header` feature required**
             pub fn custom(self, name: impl Into<Cow<'static, str>>, action: impl CustomHeadersAction<'set>) -> Self {
                 if self.0.custom.is_none() {
-                    self.0.custom = Some(Box::new(CustomHeaderMap::default()));
+                    self.0.custom = Some(Box::new(FxHashMap::default()));
                 }
                 action.perform(self, name)
             }
@@ -284,19 +246,19 @@ macro_rules! Header {
 
 impl Headers {
     #[inline(always)] pub(crate) fn insert(&mut self, name: Header, value: CowSlice) {
-        unsafe {*self.values.get_unchecked_mut(name as usize) = Some(value)}
+        unsafe {*self.standard.get_unchecked_mut(name as usize) = Some(value)}
     }
     #[cfg(feature="DEBUG")]
     #[inline(always)] pub fn _insert(&mut self, name: Header, value: CowSlice) {
-        unsafe {*self.values.get_unchecked_mut(name as usize) = Some(value)}
+        unsafe {*self.standard.get_unchecked_mut(name as usize) = Some(value)}
     }
 
     pub(crate) fn remove(&mut self, name: Header) {
-        unsafe {*self.values.get_unchecked_mut(name as usize) = None}
+        unsafe {*self.standard.get_unchecked_mut(name as usize) = None}
     }
 
     #[inline] pub(crate) fn get(&self, name: Header) -> Option<&str> {
-        match unsafe {self.values.get_unchecked(name as usize)} {
+        match unsafe {self.standard.get_unchecked(name as usize)} {
             Some(v) => Some(std::str::from_utf8(
                 unsafe {v.as_bytes()}
             ).expect("Header value is not UTF-8")),
@@ -306,7 +268,7 @@ impl Headers {
 
     pub(crate) fn append(&mut self, name: Header, value: Cow<'static, str>) {
         let value_len = value.len();
-        let target = unsafe {self.values.get_unchecked_mut(name as usize)};
+        let target = unsafe {self.standard.get_unchecked_mut(name as usize)};
 
         match target {
             Some(v) => {
@@ -332,12 +294,11 @@ impl Headers {
 }
 
 #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
-#[cfg(feature="custom-header")]
 impl Headers {
     #[inline] pub(crate) fn insert_custom(&mut self, name: CowSlice, value: CowSlice) {
         match &mut self.custom {
             Some(c) => {c.insert(name, value);}
-            None => self.custom = Some(Box::new(CustomHeaderMap::from_iter([
+            None => self.custom = Some(Box::new(FxHashMap::from_iter([
                 (name, value)
             ])))
         }
@@ -349,11 +310,11 @@ impl Headers {
     }
 }
 
+#[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
 impl Headers {
-    #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
-    pub(crate) const fn init() -> Self {
+    pub(crate) fn init() -> Self {
         Self {
-            values: [
+            standard: Box::new([
                 None, None, None, None, None,
                 None, None, None, None, None,
                 None, None, None, None, None,
@@ -363,41 +324,21 @@ impl Headers {
                 None, None, None, None, None,
                 None, None, None, None, None,
                 None, None,
-            ],
-            #[cfg(feature="custom-header")]
+            ]),
             custom: None,
         }
     }
     #[cfg(feature="DEBUG")]
-    #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
-    pub const fn __init__() -> Self {
-        Self {
-            values: [
-                None, None, None, None, None,
-                None, None, None, None, None,
-                None, None, None, None, None,
-                None, None, None, None, None,
-                None, None, None, None, None,
-                None, None, None, None, None,
-                None, None, None, None, None,
-                None, None, None, None, None,
-                None, None,
-            ],
-            #[cfg(feature="custom-header")]
-            custom: None,
-        }
+    pub fn _init() -> Self {
+        Self::init()
     }
 
-    #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
-    #[cfg(test)] pub(crate) fn from_iter(iter: impl IntoIterator<Item = (Header, &'static str)>) -> Self {
-        let mut this = Self::init();
-        for (k, v) in iter {
-            this.insert(k, CowSlice::Own(v.as_bytes().to_vec()))
-        }
-        this
+    #[inline(always)]
+    fn get_or_init_custom_mut(&mut self) -> &mut FxHashMap<CowSlice, CowSlice> {
+        self.custom.is_none().then(|| self.custom = Some(Box::new(FxHashMap::default())));
+        unsafe {self.custom.as_mut().unwrap_unchecked()}
     }
-    #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
-    #[cfg(feature="custom-header")]
+
     #[cfg(test)] pub(crate) fn from_iters(
         iter:   impl IntoIterator<Item = (Header, &'static str)>,
         custom: impl IntoIterator<Item = (&'static str, &'static str)>,
@@ -437,7 +378,7 @@ impl Headers {
             }
         }
 
-        Standard { cur:0, standard:&self.values }
+        Standard { cur:0, standard:&self.standard }
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
@@ -462,11 +403,9 @@ impl Headers {
             }
         }
 
-        #[cfg(feature="custom-header")]
         struct Custom<'i> {
             map_iter: Option<::std::collections::hash_map::Iter<'i, CowSlice, CowSlice>>
         }
-        #[cfg(feature="custom-header")]
         impl<'i> Iterator for Custom<'i> {
             type Item = (&'i str, &'i str);
             fn next(&mut self) -> Option<Self::Item> {
@@ -478,15 +417,10 @@ impl Headers {
             }
         }
 
-        #[cfg(feature="custom-header")] {
-            Iterator::chain(
-                Standard { cur:0, standard:&self.values },
-                Custom { map_iter:self.custom.as_ref().map(|box_hmap| box_hmap.iter()) }
-            )
-        }
-        #[cfg(not(feature="custom-header"))] {
-            Standard { cur:0, standard:&self.values }
-        }
+        Iterator::chain(
+            Standard { cur:0, standard:&self.standard },
+            Custom { map_iter:self.custom.as_ref().map(|box_hmap| box_hmap.iter()) }
+        )
     }
 }
 
@@ -499,7 +433,6 @@ const _: () = {
                 }
             }
             
-            #[cfg(feature="custom-header")]
             if self.custom != other.custom {
                 return false
             }

--- a/ohkami/src/response/_test.rs
+++ b/ohkami/src/response/_test.rs
@@ -53,12 +53,14 @@ async fn test_response_into_bytes() {
 
     let mut res = Response::NotFound();
     res.headers.set().Server("ohkami");
+    res.headers.set().custom("Hoge-Header", "Something-Custom");
     let res_bytes = res.into_bytes();
     assert_bytes_eq!(res_bytes, format!("\
         HTTP/1.1 404 Not Found\r\n\
         Content-Length: 0\r\n\
         Date: {__now__}\r\n\
         Server: ohkami\r\n\
+        Hoge-Header: Something-Custom\r\n\
         \r\n\
     ").into_bytes());
 }

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -83,20 +83,17 @@ pub struct Response {
     pub status:         Status,
     /// Headers of this response
     /// 
-    /// - `.{Name}()` to get the value
-    /// - `.set().{Name}(〜)` to mutate the value
-    ///   - `.set().{Name}({value})` to insert
-    ///   - `.set().{Name}(None)` to remove
-    ///   - `.set().{Name}(append({value}))` to append
-    /// 
-    /// `{value}`: `String`, `&'static str`, `Cow<&'static, str>`
+    /// - `.{Name}()`, `.custom({Name})` to get the value
+    /// - `.set().{Name}({action})`, `.set().custom({Name}, {action})` to mutate the values
     /// 
     /// ---
     /// 
-    /// *`custom-header` feature required* :
+    /// `{action}`:
+    /// - just `{value}` to insert
+    /// - `None` to remove
+    /// - `append({value})` to append
     /// 
-    /// - `.custom({Name})` to get the value
-    /// - `.set().custom({Name}, 〜)` to mutate the value like standard headers
+    /// `{value}`: `String`, `&'static str`, `Cow<&'static, str>`
     pub headers:        ResponseHeaders,
     pub(crate) content: Option<Cow<'static, [u8]>>,
 } const _: () = {

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -36,11 +36,8 @@ impl Session {
             crate::Response::InternalServerError()
         }
 
-        const LOOP_LIMIT: u8 = 16;
-
         let connection = &mut self.connection;
-
-        for _ in 0..LOOP_LIMIT {
+        loop {
             let mut req = Request::init();
             let mut req = unsafe {Pin::new_unchecked(&mut req)};
             if req.as_mut().read(connection).await.is_none() {break}


### PR DESCRIPTION
- Put in `Box<_>` and rename
  - `Request.{ __metadata => __buf__ }`
  - `Request.headers.{ values => standard }`
  - `Response.headers.{ values => standard }`
- Remove `LOOP_LIMIT` in `Session::manage`, just `loop` instead
- ( Add `benches/src/bin/hello` and, on my PC, impl the same bench app in axum, and defeated it in various conditions ! )