### PR TITLE
Fix: `QueryParams::iter`, `Response::complete` (don't use set `Date` …

### DIFF
--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -35,7 +35,7 @@ sha2          = { version = "0.10.8", default-features = false }
 
 
 [features]
-#default       = ["testing"]
+default       = ["testing"]
 
 rt_tokio      = ["dep:tokio"]
 rt_async-std  = ["dep:async-std"]
@@ -52,11 +52,11 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-default = [
-    "testing",
-    #"websocket",
-    #"rt_tokio",
-    #"rt_async-std",
-    "rt_worker",
-    "DEBUG",
-]
+#default = [
+#    "testing",
+#    #"websocket",
+#    #"rt_tokio",
+#    #"rt_async-std",
+#    "rt_worker",
+#    "DEBUG",
+#]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -35,7 +35,7 @@ sha2          = { version = "0.10.8", default-features = false }
 
 
 [features]
-default       = ["testing"]
+#default       = ["testing"]
 
 rt_tokio      = ["dep:tokio"]
 rt_async-std  = ["dep:async-std"]
@@ -52,11 +52,11 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-#default = [
-#    "testing",
-#    #"websocket",
-#    #"rt_tokio",
-#    #"rt_async-std",
-#    "rt_worker",
-#    "DEBUG",
-#]
+default = [
+    "testing",
+    #"websocket",
+    #"rt_tokio",
+    #"rt_async-std",
+    "rt_worker",
+    "DEBUG",
+]

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -303,36 +303,36 @@ impl Ohkami {
         env: ::worker::Env,
         ctx: ::worker::Context,
     ) -> ::worker::Response {
-        #[cfg(feature="DEBUG")] println!("Called `#[ohkami::worker]`; req: {req:?}");
+        #[cfg(feature="DEBUG")] ::worker::console_debug!("Called `#[ohkami::worker]`; req: {req:?}");
 
         let mut ohkami_req = crate::Request::init();
-        #[cfg(feature="DEBUG")] println!("Done `ohkami::Request::init`");
+        #[cfg(feature="DEBUG")] ::worker::console_debug!("Done `ohkami::Request::init`");
 
         let mut ohkami_req = unsafe {std::pin::Pin::new_unchecked(&mut ohkami_req)};
-        #[cfg(feature="DEBUG")] println!("Put request in `Pin`");
+        #[cfg(feature="DEBUG")] ::worker::console_debug!("Put request in `Pin`");
 
         let take_over = ohkami_req.as_mut().take_over(req, env, ctx).await;
-        #[cfg(feature="DEBUG")] println!("Done `ohkami::Request::take_over`: {ohkami_req:?}");
+        #[cfg(feature="DEBUG")] ::worker::console_debug!("Done `ohkami::Request::take_over`: {ohkami_req:?}");
 
         let ohkami_res = match take_over {
-            Ok(()) => {#[cfg(feature="DEBUG")] println!("`take_over` succeed");
+            Ok(()) => {#[cfg(feature="DEBUG")] ::worker::console_debug!("`take_over` succeed");
 
                 let router = self.into_router();
-                #[cfg(feature="DEBUG")] println!("Done `Ohkami::into_router`");
+                #[cfg(feature="DEBUG")] ::worker::console_debug!("Done `Ohkami::into_router`");
 
                 let router = router.into_radix();
-                #[cfg(feature="DEBUG")] println!("Done `TrieRouter::into_radix` (without compressions)");
+                #[cfg(feature="DEBUG")] ::worker::console_debug!("Done `TrieRouter::into_radix` (without compressions)");
                 
                 router.handle(&mut ohkami_req).await
             }
-            Err(e) => {#[cfg(feature="DEBUG")] println!("`take_over` returned an error response: {e:?}");
+            Err(e) => {#[cfg(feature="DEBUG")] ::worker::console_debug!("`take_over` returned an error response: {e:?}");
                 e
             }
         };
-        #[cfg(feature="DEBUG")] println!("Successfully generated ohkami::Response: {ohkami_res:?}");
+        #[cfg(feature="DEBUG")] ::worker::console_debug!("Successfully generated ohkami::Response: {ohkami_res:?}");
 
         let res = ohkami_res.into();
-        #[cfg(feature="DEBUG")] println!("Done `ohkami::Response` --into--> `worker::Response`: {res:?}");
+        #[cfg(feature="DEBUG")] ::worker::console_debug!("Done `ohkami::Response` --into--> `worker::Response`: {res:?}");
 
         res
     }

--- a/ohkami/src/request/queries.rs
+++ b/ohkami/src/request/queries.rs
@@ -39,10 +39,11 @@ impl QueryParams {
         self.0.as_bytes()
             .split(|b| b==&b'&')
             .map(|kv| {
-                let (k, v) = kv.split_at(
-                    kv.iter().position(|b| b==&b'=').expect("invalid query params: missing `=`")
-                );
-                (decoded_utf8(k), decoded_utf8(v))
+                let eq = kv.iter().position(|b| b==&b'=').expect("invalid query params: missing `=`");
+                (
+                    decoded_utf8(unsafe {kv.get_unchecked(..eq)}),
+                    decoded_utf8(unsafe {kv.get_unchecked(eq+1..)})
+                )
             })
     }
 }

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -117,6 +117,8 @@ impl Response {
     /// Complete HTTP spec
     #[inline]
     fn complete(&mut self) {
+        /* `wasm32-unkown-unkown` target doesn't support `time` */
+        #[cfg(not(feature="rt_worker"))]
         self.headers.set().Date(::ohkami_lib::imf_fixdate_now());
 
         if self.content.is_none() && !matches!(self.status, Status::NoContent) {

--- a/ohkami_lib/src/base64.rs
+++ b/ohkami_lib/src/base64.rs
@@ -94,6 +94,7 @@ fn encode_by(src: &[u8], encode_map: &[u8; 64], padding: Option<u8>) -> String {
 }
 
 #[inline] fn decode_by(encoded: &[u8], encode_map: &[u8; 64], padding: Option<u8>) -> Vec<u8> {
+    #[cfg(target_pointer_width = "64")]
     #[inline] fn assemble64(n: [u8; 8]) -> Option<u64> {
         let [n1, n2, n3, n4, n5, n6, n7, n8] = n.map(<u8 as Into<u64>>::into);
         (n1|n2|n3|n4|n5|n6|n7|n8 != 0xff).then_some(


### PR DESCRIPTION
## Fix
- `QueryParams::iter` ... Found returning value with `=` ( like `?name=ohkami` to `( "name", "=ohkami" )` ) and fixed
- `Response::complete` ... Don't use set `Date` in worker because it doesn't support `time`

## Change
- store `env`, `ctx` in `Request` instead of static variable ... For repeated requests in development with miniflare