### PR TITLE
Rebuild `Response`'s public methods

### DIFF
--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -6,7 +6,7 @@ use ohkami::builtin::{payload::Multipart, utils::File};
 struct FormTemplate;
 impl ohkami::IntoResponse for FormTemplate {
     fn into_response(self) -> Response {
-        Response::OK().html(include_str!("../form.html"))
+        Response::OK().with_html(include_str!("../form.html"))
     }
 }
 

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -44,7 +44,7 @@ mod hello_handler {
     impl ohkami::IntoResponse for ValidationError {
         fn into_response(self) -> Response {
             match self {
-                Self::NameIsEmpty => Response::with(Status::BadRequest).text("`name` mustn't be empty")
+                Self::NameIsEmpty => Response::BadRequest().with_text("`name` mustn't be empty")
             }
         }
     }

--- a/ohkami/src/builtin/fang/timeout.rs
+++ b/ohkami/src/builtin/fang/timeout.rs
@@ -105,7 +105,7 @@ const _: () = {
                     Poll::Ready(res) => Poll::Ready(res.into_response()),
                     Poll::Pending    => match unsafe {self.map_unchecked_mut(|t| &mut t.sleep)}.poll(cx) {
                         Poll::Pending  => Poll::Pending,
-                        Poll::Ready(_) => Poll::Ready(Response::InternalServerError().text("Timeout")),
+                        Poll::Ready(_) => Poll::Ready(Response::InternalServerError().with_text("Timeout")),
                     }
                 }
             }

--- a/ohkami/src/fangs/handler/into_handler.rs
+++ b/ohkami/src/fangs/handler/into_handler.rs
@@ -35,7 +35,7 @@ pub trait IntoHandler<T> {
     <R as FromRequest>::from_request(unsafe {
         std::mem::transmute::<&'req _, &'fr _>(req)
     })
-        .ok_or_else(|| Response::BadRequest().text("missing something expected in request"))?
+        .ok_or_else(|| Response::BadRequest().with_text("missing something expected in request"))?
         .map_err(IntoResponse::into_response)
 }
 

--- a/ohkami/src/request/from_request.rs
+++ b/ohkami/src/request/from_request.rs
@@ -38,7 +38,7 @@ pub enum FromRequestError {
 
     impl IntoResponse for FromRequestError {
         fn into_response(self) -> Response {
-            Response::InternalServerError().text(match self {
+            Response::InternalServerError().with_text(match self {
                 Self::Owned(s)  => Cow::Owned(s),
                 Self::Static(s) => Cow::Borrowed(s),
             })

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -325,10 +325,10 @@ impl Request {
         self.ctx.write(ctx);
 
         self.method  = Method::from_worker(req.method())
-            .ok_or_else(|| Response::NotImplemented().text("ohkami doesn't support `CONNECT`, `TRACE` method"))?;
+            .ok_or_else(|| Response::NotImplemented().with_text("ohkami doesn't support `CONNECT`, `TRACE` method"))?;
 
         self.__url__.write(req.url()
-            .map_err(|_| Response::BadRequest().text("Invalid request URL"))?
+            .map_err(|_| Response::BadRequest().with_text("Invalid request URL"))?
         );
         #[cfg(feature="DEBUG")] worker::console_debug!("Load __url__: {:?}", self.__url__);
 
@@ -345,7 +345,7 @@ impl Request {
         self.headers.take_over(req.headers());
 
         self.payload = Some(CowSlice::Own(req.bytes().await
-            .map_err(|_| Response::InternalServerError().text("Failed to read request payload"))?));
+            .map_err(|_| Response::InternalServerError().with_text("Failed to read request payload"))?));
 
         Ok(())
     }

--- a/ohkami/src/response/into_response.rs
+++ b/ohkami/src/response/into_response.rs
@@ -16,14 +16,13 @@ use crate::{Response, Status};
 /// }
 /// impl IntoResponse for MyResponse {
 ///     fn into_response(self) -> Response {
-///         Response::with(Status::OK)
-///             .text(self.message)
+///         Response::OK().with_text(self.message)
 ///     }
 /// }
 /// 
 /// async fn handler() -> MyResponse {
 ///     MyResponse {
-///         message: "Hello!".to_string()
+///         message: String::from("Hello!")
 ///     }
 /// }
 /// 
@@ -46,7 +45,7 @@ impl IntoResponse for Response {
 
 impl IntoResponse for Status {
     #[inline(always)] fn into_response(self) -> Response {
-        Response::with(self)
+        Response::of(self)
     }
 }
 

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -69,8 +69,8 @@ use crate::__rt__::AsyncWriter;
 /// impl IntoResponse for AppError {
 ///     fn into_response(self) -> Response {
 ///         match self {
-///             Self::A(msg) => Response::InternalServerError().text(msg),
-///             Self::B(msg) => Response::BadRequest().text(msg),
+///             Self::A(msg) => Response::InternalServerError().with_text(msg),
+///             Self::B(msg) => Response::BadRequest().with_text(msg),
 ///         }
 ///     }
 /// }
@@ -103,7 +103,7 @@ pub struct Response {
     pub(crate) content: Option<Cow<'static, [u8]>>,
 } const _: () = {
     impl Response {
-        #[inline(always)] pub fn with(status: Status) -> Self {
+        #[inline(always)] pub fn of(status: Status) -> Self {
             Self {
                 status,
                 headers: ResponseHeaders::new(),
@@ -166,11 +166,27 @@ impl Response {
         self.drop_content();
         self
     }
-
-    #[inline] pub fn text<Text: Into<Cow<'static, str>>>(mut self, text: Text) -> Self {
-        self.set_text(text);
+    pub fn set_content(&mut self,
+        content_type: &'static str,
+        content:      impl Into<Cow<'static, [u8]>>,
+    ) {
+        let content = content.into();
+        self.headers.set()
+            .ContentType(content_type)
+            .ContentLength(content.len().to_string());
+        self.content =Some(content);
+    }
+    pub fn with_content(mut self,
+        content_type: &'static str,
+        content:      impl Into<Cow<'static, [u8]>>,
+    ) -> Self {
+        self.set_content(content_type, content);
         self
     }
+    pub fn content(&self) -> Option<&[u8]> {
+        self.content.as_ref().map(Cow::as_ref)
+    }
+
     #[inline] pub fn set_text<Text: Into<Cow<'static, str>>>(&mut self, text: Text) {
         let body = text.into();
 
@@ -182,11 +198,11 @@ impl Response {
             Cow::Owned(string) => Cow::Owned(string.into_bytes()),
         });
     }
-
-    #[inline] pub fn html<HTML: Into<Cow<'static, str>>>(mut self, html: HTML) -> Self {
-        self.set_html(html);
+    #[inline] pub fn with_text<Text: Into<Cow<'static, str>>>(mut self, text: Text) -> Self {
+        self.set_text(text);
         self
     }
+
     #[inline] pub fn set_html<HTML: Into<Cow<'static, str>>>(&mut self, html: HTML) {
         let body = html.into();
 
@@ -198,11 +214,11 @@ impl Response {
             Cow::Owned(string) => Cow::Owned(string.into_bytes()),
         });
     }
-
-    #[inline] pub fn json<JSON: serde::Serialize>(mut self, json: JSON) -> Self {
-        self.set_json(json);
+    #[inline] pub fn with_html<HTML: Into<Cow<'static, str>>>(mut self, html: HTML) -> Self {
+        self.set_html(html);
         self
     }
+
     #[inline] pub fn set_json<JSON: serde::Serialize>(&mut self, json: JSON) {
         let body = ::serde_json::to_vec(&json).unwrap();
 
@@ -211,11 +227,12 @@ impl Response {
             .ContentLength(body.len().to_string());
         self.content = Some(Cow::Owned(body));
     }
-
-    pub unsafe fn json_str<JSONString: Into<Cow<'static, str>>>(mut self, json_str: JSONString) -> Self {
-        self.set_json_str(json_str);
+    #[inline] pub fn with_json<JSON: serde::Serialize>(mut self, json: JSON) -> Self {
+        self.set_json(json);
         self
     }
+
+    /// SAFETY: Argument `json_str` is a **valid JSON**
     pub unsafe fn set_json_str<JSONString: Into<Cow<'static, str>>>(&mut self, json_str: JSONString) {
         let body = match json_str.into() {
             Cow::Borrowed(str) => Cow::Borrowed(str.as_bytes()),
@@ -226,6 +243,11 @@ impl Response {
             .ContentType("application/json; charset=UTF-8")
             .ContentLength(body.len().to_string());
         self.content = Some(body);
+    }
+    /// SAFETY: Argument `json_str` is a **valid JSON**
+    pub unsafe fn with_json_str<JSONString: Into<Cow<'static, str>>>(mut self, json_str: JSONString) -> Self {
+        self.set_json_str(json_str);
+        self
     }
 }
 

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -155,11 +155,12 @@ impl Response {
 }
 
 impl Response {
-    pub fn drop_content(&mut self) {
-        self.content = None;
+    pub fn drop_content(&mut self) -> Option<Cow<'static, [u8]>> {
+        let old_content = self.content.take();
         self.headers.set()
             .ContentType(None)
             .ContentLength(None);
+        old_content
     }
     pub fn without_content(mut self) -> Self {
         self.drop_content();

--- a/ohkami/src/typed/status.rs
+++ b/ohkami/src/typed/status.rs
@@ -11,14 +11,14 @@ trait ResponseBody {
 const _: () = {
     impl ResponseBody for () {
         fn into_response_with(self, status: Status) -> Response {
-            Response::with(status)
+            Response::of(status)
         }
     }
 
     impl<P: Payload + Serialize> ResponseBody for P {
         #[inline]
         fn into_response_with(self, status: Status) -> Response {
-            let mut res = Response::with(status);
+            let mut res = Response::of(status);
             if let Err(e) = self.inject(&mut res) {
                 return (|| {
                     eprintln!("Failed to serialize {} payload: {e}", P::Type::CONTENT_TYPE);
@@ -41,13 +41,13 @@ const _: () = {
                 impl ResponseBody for $t {
                     #[inline]
                     fn into_response_with(self, status: Status) -> Response {
-                        Response::with(status).text(self)
+                        Response::of(status).with_text(self)
                     }
                 }
                 impl IntoResponse for $t {
                     #[inline]
                     fn into_response(self) -> Response {
-                        Response::OK().text(self)
+                        Response::OK().with_text(self)
                     }
                 }
             )*
@@ -178,7 +178,7 @@ macro_rules! generate_redirects {
 
             impl IntoResponse for $status {
                 #[inline] fn into_response(self) -> Response {
-                    let mut res = Response::with(Status::$status);
+                    let mut res = Response::of(Status::$status);
                     res.headers.set()
                         .Location(self.location);
                     res

--- a/ohkami_macros/src/query.rs
+++ b/ohkami_macros/src/query.rs
@@ -108,7 +108,7 @@ pub(super) fn Query(target: TokenStream) -> Result<TokenStream> {
                 fn from_request(req: &#from_request_lifetime ::ohkami::Request) -> ::std::option::Option<::std::result::Result<Self, Self::Error>> {
                     req.query::<#cloned_name<#generics_params>>().map(|result| result
                         .map(Into::into)
-                        .map_err(|e| ::ohkami::Response::BadRequest().text(::std::format!("Unexpected query parameters: {e}")))
+                        .map_err(|e| ::ohkami::Response::BadRequest().with_text(::std::format!("Unexpected query parameters: {e}")))
                     )
                 }
             }


### PR DESCRIPTION
For more consistent names, and, some fangs like HTML layout fang:

```rs
struct LayoutFang;
impl FangAction for LayoutFang {
    async fn back<'b>(&'b self, res: &'b mut Response) {
        if res.headers.ContentType().is_some_and(|ct| ct.starts_with("text/html")) {
            let inner = res.drop_content();
            res.set_html(some_layout_fn(inner));
        }
    }
}
```