### PR TITLE
Fix Cookie handling

### DIFF
--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -104,7 +104,228 @@ mod x_websocket;
 #[cfg(feature="rt_worker")]
 pub use ::ohkami_macros::{worker, bindings};
 
-pub mod header {
+pub mod header {#![allow(non_snake_case)]
+    pub(crate) mod private {
+        use std::borrow::Cow;
+
+        pub struct Append(pub(crate) Cow<'static, str>);
+
+        pub enum SameSitePolicy {
+            Strict,
+            Lax,
+            None,
+        }
+        impl SameSitePolicy {
+            const fn as_str(&self) -> &'static str {
+                match self {
+                    Self::Strict => "Strict",
+                    Self::Lax    => "Lax",
+                    Self::None   => "None",
+                }
+            }
+            const fn from_bytes(bytes: &[u8]) -> Option<Self> {
+                match bytes {
+                    b"Strict" => Some(Self::Strict),
+                    b"Lax"    => Some(Self::Lax),
+                    b"None"   => Some(Self::None),
+                    _ => None
+                }
+            }
+        }
+
+        pub struct SetCookie<'c> {
+            Cookie:   (&'c str, Cow<'c, str>),
+            Expires:  Option<Cow<'c, str>>,
+            MaxAge:   Option<u64>,
+            Domain:   Option<Cow<'c, str>>,
+            Path:     Option<Cow<'c, str>>,
+            Secure:   Option<bool>,
+            HttpOnly: Option<bool>,
+            SameSite: Option<SameSitePolicy>,
+        }
+        impl<'c> SetCookie<'c> {
+            pub fn Cookie(&self) -> (&str, &str) {
+                let (name, value) = &self.Cookie;
+                (name, &value)
+            }
+            pub fn Expires(&self) -> Option<&str> {
+                self.Expires.as_deref()
+            }
+            pub const fn MaxAge(&self) -> Option<u64> {
+                self.MaxAge
+            }
+            pub fn Domain(&self) -> Option<&str> {
+                self.Domain.as_deref()
+            }
+            pub fn Path(&self) -> Option<&str> {
+                self.Path.as_deref()
+            }
+            pub const fn Secure(&self) -> Option<bool> {
+                self.Secure
+            }
+            pub const fn HttpOnly(&self) -> Option<bool> {
+                self.HttpOnly
+            }
+            /// `Some`: `"Lax" | "None" | "Strict"`
+            pub const fn SameSite(&self) -> Option<&'static str> {
+                match &self.SameSite {
+                    None         => None,
+                    Some(policy) => Some(policy.as_str())
+                }
+            }
+
+            pub(crate) fn from_raw(str: &'c str) -> Result<Self, String> {
+                let mut r = byte_reader::Reader::new(str.as_bytes());
+
+                let mut this = {
+                    let name  = std::str::from_utf8(r.read_until(b"=")).map_err(|e| format!("Invalid Cookie name: {e}"))?;
+                    r.consume("=").ok_or_else(|| format!("No `=` found in a `Set-Cookie` header value"))?;
+                    let value = std::str::from_utf8(r.read_until(b"; ")).map_err(|e| format!("Invalid Cookie value: {e}"))?;
+
+                    Self {
+                        Cookie: (name, Cow::Borrowed(value)),
+                        Expires:  None,
+                        MaxAge:   None,
+                        Domain:   None,
+                        Path:     None,
+                        SameSite: None,
+                        Secure:   None,
+                        HttpOnly: None,
+                    }
+                };
+
+                while r.consume("; ").is_some() {
+                    let directive = r.read_until(b"; ");
+                    let mut r = byte_reader::Reader::new(directive);
+                    match r.consume_oneof([
+                        "Expires", "Max-Age", "Domain", "Path", "SameSite", "Secure", "HttpOnly"
+                    ]) {
+                        Some(0) => {
+                            r.consume("=").ok_or_else(|| format!("Invalid `Expires`: No `=` found"))?;
+                            let value = std::str::from_utf8(r.read_until(b"; ")).map_err(|e| format!("Invalid `Expires`: {e}"))?;
+                            this.Expires = Some(Cow::Borrowed(value))
+                        },
+                        Some(1) => {
+                            r.consume("=").ok_or_else(|| format!("Invalid `Max-Age`: No `=` found"))?;
+                            let value = r.read_until(b"; ").iter().fold(0, |secs, d| 10*secs + (*d - b'0') as u64);
+                            this.MaxAge = Some(value)
+                        }
+                        Some(2) => {
+                            r.consume("=").ok_or_else(|| format!("Invalid `Path`: No `=` found"))?;
+                            let value = std::str::from_utf8(r.read_until(b"; ")).map_err(|e| format!("Invalid `Path`: {e}"))?;
+                            this.Path = Some(Cow::Borrowed(value))
+                        }
+                        Some(3) => {
+                            r.consume("=").ok_or_else(|| format!("Invalid `SameSite`: No `=` found"))?;
+                            this.SameSite = SameSitePolicy::from_bytes(r.read_until(b"; "));
+                        }
+                        Some(4) => this.Secure = Some(true),
+                        Some(5) => this.HttpOnly = Some(true),
+                        _ => return Err((|| format!("Unkown directive: `{}`", r.remaining().escape_ascii()))())
+                    }
+                }
+
+                Ok(this)
+            }
+        }
+
+        pub struct SetCookieBuilder(SetCookie<'static>);
+        impl SetCookieBuilder {
+            #[inline]
+            pub(crate) fn new(cookie_name: &'static str, cookie_value: impl Into<Cow<'static, str>>) -> Self {
+                Self(SetCookie {
+                    Cookie: (cookie_name, cookie_value.into()),
+                    Expires: None, MaxAge: None, Domain: None, Path: None, Secure: None, HttpOnly: None, SameSite: None,
+                })
+            }
+            pub(crate) fn build(self) -> String {
+                let mut bytes = Vec::new();
+
+                let (name, value) = self.0.Cookie; {
+                    bytes.extend_from_slice(name.as_bytes());
+                    bytes.push(b'=');
+                    bytes.extend_from_slice(value.as_bytes())
+                }
+                if let Some(Expires) = self.0.Expires {
+                    bytes.extend_from_slice(b"; Expires=");
+                    bytes.extend_from_slice(Expires.as_bytes());
+                }
+                if let Some(MaxAge) = self.0.MaxAge {
+                    bytes.extend_from_slice(b"; MaxAge=");
+                    bytes.extend_from_slice(MaxAge.to_string().as_bytes());
+                }
+                if let Some(Domain) = self.0.Domain {
+                    bytes.extend_from_slice(b"; Domain=");
+                    bytes.extend_from_slice(Domain.as_bytes());
+                }
+                if let Some(Path) = self.0.Path {
+                    bytes.extend_from_slice(b"; Path=");
+                    bytes.extend_from_slice(Path.as_bytes());
+                }
+                if let Some(true) = self.0.Secure {
+                    bytes.extend_from_slice(b"; Secure");
+                }
+                if let Some(true) = self.0.HttpOnly {
+                    bytes.extend_from_slice(b"; HttpOnly");
+                }
+                if let Some(SameSite) = self.0.SameSite {
+                    bytes.extend_from_slice(b"; SameSite=");
+                    bytes.extend_from_slice(SameSite.as_str().as_bytes());
+                }
+
+                unsafe {// SAFETY: All fields and punctuaters is UTF-8
+                    String::from_utf8_unchecked(bytes)
+                }
+            }
+
+            #[inline]
+            pub fn Expires(mut self, Expires: impl Into<Cow<'static, str>>) -> Self {
+                self.0.Expires = Some(Expires.into());
+                self
+            }
+            #[inline]
+            pub const fn MaxAge(mut self, MaxAge: u64) -> Self {
+                self.0.MaxAge = Some(MaxAge);
+                self
+            }
+            #[inline]
+            pub fn Domain(mut self, Domain: impl Into<Cow<'static, str>>) -> Self {
+                self.0.Domain = Some(Domain.into());
+                self
+            }
+            #[inline]
+            pub fn Path(mut self, Path: impl Into<Cow<'static, str>>) -> Self {
+                self.0.Path = Some(Path.into());
+                self
+            }
+            #[inline]
+            pub const fn Secure(mut self) -> Self {
+                self.0.Secure = Some(true);
+                self
+            }
+            #[inline]
+            pub const fn HttpOnly(mut self) -> Self {
+                self.0.HttpOnly = Some(true);
+                self
+            }
+            #[inline]
+            pub const fn SameSiteLax(mut self) -> Self {
+                self.0.SameSite = Some(SameSitePolicy::Lax);
+                self
+            }
+            #[inline]
+            pub const fn SameSiteNone(mut self) -> Self {
+                self.0.SameSite = Some(SameSitePolicy::None);
+                self
+            }
+            #[inline]
+            pub const fn SameSiteStrict(mut self) -> Self {
+                self.0.SameSite = Some(SameSitePolicy::Strict);
+                self
+            }
+        }
+    }
+
     /// Passed to `{Request/Response}.headers.set().Name( 〜 )` and
     /// append `value` to the header.
     /// 
@@ -134,10 +355,6 @@ pub mod header {
     /// ```
     pub fn append(value: impl Into<std::borrow::Cow<'static, str>>) -> private::Append {
         private::Append(value.into())
-    }
-
-    pub(crate) mod private {
-        pub struct Append(pub(crate) std::borrow::Cow<'static, str>);
     }
 }
 

--- a/ohkami/src/request/headers.rs
+++ b/ohkami/src/request/headers.rs
@@ -410,7 +410,6 @@ impl Headers {
                 None,
             ]),
             custom: None,
-            cookie: None,
         }
     }
     #[cfg(feature="DEBUG")]

--- a/ohkami/src/request/headers.rs
+++ b/ohkami/src/request/headers.rs
@@ -445,15 +445,10 @@ impl Headers {
                     standard,
                     CowSlice::Own(v.into_boxed_str().into())
                 ),
-                None => match &*k {
-                    "Cookie" | "cookie" => self.append_cookie(
-                        Slice::from_bytes(Box::leak(v.into_boxed_str()).as_bytes())
-                    ),
-                    _ => self.insert_custom(
-                        Slice::from_bytes(Box::leak(k.into_boxed_str()).as_bytes()),
-                        CowSlice::Own(v.into_boxed_str().into())
-                    )
-                }
+                None => self.insert_custom(
+                    Slice::from_bytes(Box::leak(k.into_boxed_str()).as_bytes()),
+                    CowSlice::Own(v.into_boxed_str().into())
+                )
             }
         }
     }

--- a/ohkami/src/request/headers.rs
+++ b/ohkami/src/request/headers.rs
@@ -407,7 +407,7 @@ impl Headers {
                 None, None, None, None, None,
                 None, None, None, None, None,
                 None, None, None, None, None,
-                None,
+                None, None,
             ]),
             custom: None,
         }

--- a/ohkami/src/request/headers.rs
+++ b/ohkami/src/request/headers.rs
@@ -8,7 +8,6 @@ use rustc_hash::FxHashMap;
 pub struct Headers {
     standard: Box<[Option<CowSlice>; N_CLIENT_HEADERS]>,
     custom:   Option<Box<FxHashMap<Slice, CowSlice>>>,
-    cookie:   Option<Box<Vec<Slice>>>,
 }
 
 pub struct SetHeaders<'set>(
@@ -179,6 +178,10 @@ macro_rules! Header {
         #[allow(non_snake_case)]
         impl Headers {
             $(
+                /// See the header value(s).
+                /// 
+                /// Multiple values are conbined into a comma-separated string, that can be iterated just by `.split(", ")`,\
+                /// except for `Cookie` that by semicolon (see `Cookies` helper method).
                 #[inline(always)]
                 pub fn $konst(&self) -> Option<&str> {
                     self.get(Header::$konst)
@@ -204,7 +207,7 @@ macro_rules! Header {
             )*
         }
     };
-} Header! {41;
+} Header! {42;
     Accept:                      b"Accept" | b"accept",
     AcceptEncoding:              b"Accept-Encoding" | b"accept-encoding",
     AcceptLanguage:              b"Accept-Language" | b"accept-language",
@@ -219,7 +222,7 @@ macro_rules! Header {
     ContentLength:               b"Content-Length" | b"content-length",
     ContentLocation:             b"Content-Location" | b"content-location",
     ContentType:                 b"Content-Type" | b"content-type",
-    // Cookie:                      b"Cookie" | b"cookie",
+    Cookie:                      b"Cookie" | b"cookie",
     Date:                        b"Date" | b"date",
     Expect:                      b"Expect" | b"expect",
     Forwarded:                   b"Forwarded" | b"forwarded",
@@ -249,18 +252,24 @@ macro_rules! Header {
     Via:                         b"Via" | b"via",
 }
 
-const _: () = {
-    #[allow(non_snake_case)]
-    impl Headers {
-        pub fn Cookie(&self) -> impl Iterator<Item = &str> {
-            self.cookie.as_ref().map(|cookies|
-                cookies.iter().map(|slice| std::str::from_utf8(unsafe {
-                    slice.as_bytes()
-                }).expect("Non UTF-8 Cookie"))
+#[allow(non_snake_case)]
+impl Headers {
+    /// Util method to parse semicolon-separated Cookies into an iterator of
+    /// `(name, value)`.
+    /// 
+    /// Invalid Cookie that doesn't contain `=` or contains multiple `=`s is just ignored.
+    pub fn Cookies(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.Cookie()
+            .map(|cookie_list| cookie_list.split("; ")
+                .filter_map(|key_value| {
+                    let mut key_value = key_value.split('=');
+                    let key   = key_value.next()?;
+                    let value = key_value.next()?;
+                    key_value.next().is_none().then_some((key, value))
+                })
             ).into_iter().flatten()
-        }
     }
-};
+}
 
 impl Headers {
     #[inline(always)]
@@ -338,12 +347,10 @@ impl Headers {
         let target = unsafe {self.standard.get_unchecked_mut(name as usize)};
 
         match target {
+            None => *target = Some(value),
             Some(v) => unsafe {
                 v.extend_from_slice(b",");
                 v.extend_from_slice(value.as_bytes());
-            }
-            None => {
-                *target = Some(value)
             }
         }
     }
@@ -382,14 +389,6 @@ impl Headers {
             None => {
                 custom.insert(name, value);
             }
-        }
-    }
-
-    #[allow(unused)]
-    #[inline] pub(crate) fn append_cookie(&mut self, cookie: Slice) {
-        match &mut self.cookie {
-            None          => self.cookie = Some(Box::new(vec![cookie])),
-            Some(cookies) => cookies.push(cookie),
         }
     }
 }

--- a/ohkami/src/response/_test.rs
+++ b/ohkami/src/response/_test.rs
@@ -69,8 +69,8 @@ async fn test_response_into_bytes() {
     res.headers.set()
         .Server("ohkami")
         .custom("Hoge-Header", "Something-Custom")
-        .SetCookie("id=A")
-        .SetCookie("id=B");
+        .SetCookie("id", "42", |d|d.Path("/").SameSiteLax())
+        .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict());
     let res_bytes = res.into_bytes();
     assert_bytes_eq!(res_bytes, format!("\
         HTTP/1.1 404 Not Found\r\n\
@@ -78,8 +78,8 @@ async fn test_response_into_bytes() {
         Date: {__now__}\r\n\
         Content-Length: 0\r\n\
         Hoge-Header: Something-Custom\r\n\
-        Set-Cookie: id=A\r\n\
-        Set-Cookie: id=B\r\n\
+        Set-Cookie: id=42; Path=/; SameSite=Lax\r\n\
+        Set-Cookie: name=John; Path=/where; SameSite=Strict\r\n\
         \r\n\
     ").into_bytes());
 }

--- a/ohkami/src/response/_test_headers.rs
+++ b/ohkami/src/response/_test_headers.rs
@@ -1,4 +1,4 @@
-use crate::header::append;
+use crate::header::{append, private::{SameSitePolicy, SetCookie}};
 use super::ResponseHeaders;
 
 
@@ -18,4 +18,48 @@ use super::ResponseHeaders;
     assert_eq!(h.custom("Custom-Header"), Some("A"));
     h.set().custom("Custom-Header", append("B"));
     assert_eq!(h.custom("Custom-Header"), Some("A,B"));
+}
+
+#[test] fn parse_setcookie_headers() {
+    let mut h = ResponseHeaders::new();
+    h.set().SetCookie("id", "42", |d|d.Path("/").SameSiteLax().Secure());
+    assert_eq!(h.SetCookie().collect::<Vec<_>>(), [
+        SetCookie {
+            Cookie:   ("id", "42".into()),
+            Expires:  None,
+            MaxAge:   None,
+            Domain:   None,
+            Path:     Some("/".into()),
+            Secure:   Some(true),
+            HttpOnly: None,
+            SameSite: Some(SameSitePolicy::Lax),
+        }
+    ]);
+
+    let mut h = ResponseHeaders::new();
+    h.set()
+        .SetCookie("id", "10", |d|d.Path("/").SameSiteLax().Secure())
+        .SetCookie("id", "42", |d|d.MaxAge(1280).HttpOnly().Path("/where").SameSiteLax().Secure());
+    assert_eq!(h.SetCookie().collect::<Vec<_>>(), [
+        SetCookie {
+            Cookie:   ("id", "10".into()),
+            Expires:  None,
+            MaxAge:   None,
+            Domain:   None,
+            Path:     Some("/".into()),
+            Secure:   Some(true),
+            HttpOnly: None,
+            SameSite: Some(SameSitePolicy::Lax),
+        },
+        SetCookie {
+            Cookie:   ("id", "42".into()),
+            Expires:  None,
+            MaxAge:   Some(1280),
+            Domain:   None,
+            Path:     Some("/where".into()),
+            Secure:   Some(true),
+            HttpOnly: Some(true),
+            SameSite: Some(SameSitePolicy::Lax),
+        },
+    ]);
 }

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -287,7 +287,6 @@ macro_rules! Header {
     [22] SecWebSocketProtocol:            b"Sec-WebSocket-Protocol",
     [21] SecWebSocketVersion:             b"Sec-WebSocket-Version",
     [6]  Server:                          b"Server",
-    // [10] SetCookie:                       b"Set-Cookie",
     [25] StrictTransportSecurity:         b"Strict-Transport-Security",
     [7]  Trailer:                         b"Trailer",
     [17] TransferEncoding:                b"Transfer-Encoding",
@@ -317,8 +316,10 @@ const _: () = {
     impl<'s> SetHeaders<'s> {
         /// Add new `Set-Cookie` header in the response.
         /// 
-        /// When you call this N times, the response has N different
-        /// `Set-Cookie` headers.
+        /// - When you call this N times, the response has N different
+        ///   `Set-Cookie` headers.
+        /// - Cookie value (second argument) is precent encoded when the
+        ///   response is sended.
         /// 
         /// ---
         /// *example.rs*

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use crate::header::private::Append;
+use crate::header::private::{Append, SetCookie, SetCookieBuilder};
 use rustc_hash::FxHashMap;
 
 
@@ -301,9 +301,15 @@ macro_rules! Header {
 #[allow(non_snake_case)]
 const _: () = {
     impl Headers {
-        pub fn SetCookie(&self) -> impl Iterator<Item = &str> {
+        pub fn SetCookie(&self) -> impl Iterator<Item = SetCookie<'_>> {
             self.setcookie.as_ref().map(|setcookies|
-                setcookies.iter().map(Cow::as_ref)
+                setcookies.iter().filter_map(|raw| match SetCookie::from_raw(raw) {
+                    Ok(valid) => Some(valid),
+                    Err(_err) => {
+                        #[cfg(debug_assertions)] eprintln!("Invalid `Set-Cookie`: {_err}");
+                        None
+                    }
+                })
             ).into_iter().flatten()
         }
     }
@@ -311,10 +317,28 @@ const _: () = {
     impl<'s> SetHeaders<'s> {
         /// Add new `Set-Cookie` header in the response.
         /// 
-        /// When you call this N times, the response has N *sepearated*
-        /// `Set-Cookie` headers. ( This is specialized behavior... )
-        pub fn SetCookie(self, setcookie: impl Into<Cow<'static, str>>) -> Self {
-            let setcookie = setcookie.into();
+        /// When you call this N times, the response has N different
+        /// `Set-Cookie` headers.
+        /// 
+        /// ---
+        /// *example.rs*
+        /// ```
+        /// use ohkami::Response;
+        /// 
+        /// fn mutate_header(res: &mut Response) {
+        ///     res.headers.set()
+        ///         .Server("ohkami")
+        ///         .SetCookie("id", "42", |d|d.Path("/").SameSiteLax())
+        ///         .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict());
+        /// }
+        /// ```
+        #[inline]
+        pub fn SetCookie(self,
+            name:  &'static str,
+            value: impl Into<Cow<'static, str>>,
+            directives: impl FnOnce(SetCookieBuilder)->SetCookieBuilder
+        ) -> Self {
+            let setcookie: Cow<'static, str> = directives(SetCookieBuilder::new(name, value)).build().into();
             self.0.size += "Set-Cookie: ".len() + setcookie.len() + "\r\n".len();
             match self.0.setcookie.as_mut() {
                 None             => self.0.setcookie = Some(Box::new(vec![setcookie])),
@@ -409,7 +433,7 @@ impl Headers {
                 None, None, None, None, None,
                 None, None, None, None,
             ]),
-            insertlog: Vec::with_capacity(1 << 4),
+            insertlog: Vec::with_capacity(8),
             custom:    None,
             setcookie: None,
             size:      "\r\n".len(),
@@ -469,9 +493,13 @@ impl Headers {
             }
         }
 
+        let setcookies = self.setcookie.as_ref().map(|setcookies|
+            setcookies.iter().map(Cow::as_ref)
+        ).into_iter().flatten();
+
         Standard { map: &self.standard, cur: 0 }
             .chain(Custom { map: self.custom.as_ref().map(|box_hmap| box_hmap.iter()) })
-            .chain(self.SetCookie().map(|setcookie| ("Set-Cookie", setcookie)))
+            .chain(setcookies.map(|setcookie| ("Set-Cookie", setcookie)))
     }
 
     #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]


### PR DESCRIPTION
- Update `RequestHeaders::Cookie`: return iterator of (name, value)
- Add `header::private::{SetCookie, SetCookieBuilder}` and use them from `ResponseHeaders`