### PR TITLE
Partially support cargo workspace in `#[bindings]`

### DIFF
--- a/ohkami_macros/Cargo.toml
+++ b/ohkami_macros/Cargo.toml
@@ -25,5 +25,5 @@ toml          = { optional = true, version = "0.8.12", features = ["parse"], def
 worker = ["dep:toml"]
 
 ##### DEBUG #####
-# DEBUG   = ["worker"]
-# default = ["DEBUG"]
+#DEBUG   = ["worker"]
+#default = ["DEBUG"]


### PR DESCRIPTION
Search workspace members' wrangler.tomls if wrangler.toml is not found in project root