### PR TITLE
`#[Payload]`:  take validating expression(s) in `where 〜`

### DIFF
--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -31,7 +31,7 @@ mod hello_handler {
     }
 
 
-    #[Payload(JSON/D where Self::validate)]
+    #[Payload(JSON/D where self.validate())]
     pub struct HelloRequest<'n> {
         name:   &'n str,
         repeat: Option<usize>,

--- a/ohkami/src/typed/payload.rs
+++ b/ohkami/src/typed/payload.rs
@@ -115,7 +115,7 @@ pub trait Payload: Sized {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     fn validate(&self) -> Result<(), impl std::fmt::Display> {
         Result::<(), std::convert::Infallible>::Ok(())
     }

--- a/ohkami_macros/src/payload.rs
+++ b/ohkami_macros/src/payload.rs
@@ -84,7 +84,7 @@ struct Validation {
         quote! {
             #[inline]
             fn validate(&self) -> std::result::Result<(), impl std::fmt::Display> {
-                #validate(self)
+                #validate
             }
         }
     }


### PR DESCRIPTION
instead of a validating method itself