### PR TITLE
Improve error reportings

### DIFF
--- a/ohkami/src/builtin/fang/cors.rs
+++ b/ohkami/src/builtin/fang/cors.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use crate::{header::append, Fang, FangProc, IntoResponse, Method, Request, Response, Status};
+use crate::{header::append, log_error, Fang, FangProc, IntoResponse, Method, Request, Response, Status};
 
 
 /// # Builtin fang for CORS config
@@ -81,7 +81,7 @@ impl CORS {
 
     pub fn AllowCredentials(mut self) -> Self {
         if self.AllowOrigin.is_any() {
-            #[cfg(debug_assertions)] eprintln!("\
+            #[cfg(debug_assertions)] log_error!("\
                 [WRANING] \
                 'Access-Control-Allow-Origin' header \
                 must not have wildcard '*' when the request's credentials mode is 'include' \

--- a/ohkami/src/fangs/handler/into_handler.rs
+++ b/ohkami/src/fangs/handler/into_handler.rs
@@ -1,7 +1,7 @@
 use std::{future::Future, pin::Pin};
 use ohkami_lib::percent_decode_utf8;
 use super::Handler;
-use crate::{Response, FromRequest, FromParam, Request, IntoResponse};
+use crate::{log_error, Response, FromRequest, FromParam, Request, IntoResponse};
 
 
 pub trait IntoHandler<T> {
@@ -17,7 +17,7 @@ pub trait IntoHandler<T> {
 ) -> Result<P, Response> {
     let param = percent_decode_utf8(param_bytes_maybe_percent_encoded)
         .map_err(|_e| {
-            #[cfg(debug_assertions)] eprintln!(
+            #[cfg(debug_assertions)] log_error!(
                 "[WARNING] Failed to decode percent encoding `{}`: {_e}",
                 param_bytes_maybe_percent_encoded.escape_ascii()
             );

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -31,6 +31,16 @@
 
 #[allow(unused)]
 mod __rt__ {
+    #[macro_export]
+    macro_rules! log_error {
+        ( $( $t:tt )* ) => {{
+            eprintln!( $( $t )* );
+
+            #[cfg(feature="rt_worker")]
+            worker::console_error!( $( $t )* );
+        }};
+    }
+
     #[cfg(all(feature="rt_tokio", feature="DEBUG"))]
     pub(crate) use tokio::test;
     #[allow(unused)]

--- a/ohkami/src/ohkami/build.rs
+++ b/ohkami/src/ohkami/build.rs
@@ -2,7 +2,7 @@
 
 use super::router::{TrieRouter, RouteSections};
 use crate::fangs::{Handler, IntoHandler};
-use crate::Ohkami;
+use crate::{Ohkami, log_error};
 
 
 macro_rules! Handlers {
@@ -88,7 +88,7 @@ pub struct Dir {
                         .collect::<std::io::Result<Vec<_>>>()?;
 
                     if path_sections.last().unwrap().starts_with('.') {
-                        eprintln!("\
+                        log_error!("\
                             =========\n\
                             [WARNING] `Route::Dir`: found `{}` in directory `{}`, \
                             are you sure to serve this file？\n\

--- a/ohkami/src/ohkami/router/trie.rs
+++ b/ohkami/src/ohkami/router/trie.rs
@@ -2,6 +2,7 @@ use std::{borrow::Cow, sync::Arc};
 use super::{RouteSection, RouteSections};
 use super::super::build::{Handlers, ByAnother};
 use crate::fangs::{BoxedFPC, Fangs, Handler};
+use crate::log_error;
 
 
 #[derive(Debug)]
@@ -207,7 +208,7 @@ impl TrieRouter {
         if let Err(e) = self.root.register_handlers(route.into_iter(), HandlerMap {
             GET, PUT, POST, PATCH, DELETE
         }) {
-            eprintln!("Failed to register handlers: {e}");
+            log_error!("Failed to register handlers: {e}");
             std::process::exit(1)
         }
     }

--- a/ohkami/src/request/from_request.rs
+++ b/ohkami/src/request/from_request.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use crate::{IntoResponse, Request, Response};
+use crate::{log_error, IntoResponse, Request, Response};
 
 
 pub enum FromRequestError {
@@ -147,7 +147,7 @@ pub trait FromParam<'p>: Sized {
         type Error = FromRequestError;
         fn from_param(param: Cow<'p, str>) -> Result<Self, Self::Error> {
             #[cold] fn unexpectedly_percent_encoded() -> FromRequestError {
-                eprintln!("\
+                log_error!("\
                     \n\
                     =========\n\
                     [WARNING] \

--- a/ohkami/src/request/memory.rs
+++ b/ohkami/src/request/memory.rs
@@ -4,6 +4,8 @@ use std::{
     hash::{Hasher, BuildHasherDefault},
 };
 
+use crate::log_error;
+
 
 pub struct Store(
     Option<Box<
@@ -94,7 +96,7 @@ super::FromRequest<'req> for Memory<'req, Data> {
             Some(d) => Some(Ok(d)),
             None => {
                 #[cfg(debug_assertions)] {
-                    eprintln!(
+                    log_error!(
                         "`Memory` of type `{}` was not found",
                         std::any::type_name::<Data>()
                     )

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -161,14 +161,14 @@ impl Request {
         mut self: Pin<&mut Self>,
         stream:   &mut (impl AsyncReader + Unpin),
     ) -> Result<Option<()>, crate::Response> {
-        use crate::Response;
+        use crate::{log_error, Response};
 
         match stream.read(&mut *self.__buf__).await {
             Ok (0) => return Ok(None),
             Err(e) => return match e.kind() {
                 std::io::ErrorKind::ConnectionReset => Ok(None),
                 _ => Err((|| {
-                    eprintln!("Failed to read stream: {e}");
+                    log_error!("Failed to read stream: {e}");
                     Response::InternalServerError()
                 })())
             },

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use crate::header::private::{Append, SetCookie, SetCookieBuilder};
+use crate::{header::private::{Append, SetCookie, SetCookieBuilder}, log_error};
 use rustc_hash::FxHashMap;
 
 
@@ -305,7 +305,7 @@ const _: () = {
                 setcookies.iter().filter_map(|raw| match SetCookie::from_raw(raw) {
                     Ok(valid) => Some(valid),
                     Err(_err) => {
-                        #[cfg(debug_assertions)] eprintln!("Invalid `Set-Cookie`: {_err}");
+                        #[cfg(debug_assertions)] log_error!("Invalid `Set-Cookie`: {_err}");
                         None
                     }
                 })

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -300,12 +300,12 @@ const _: () = {
 
     #[cfg(test)]
     fn try_response() {
-        use crate::{Request};
+        use crate::{log_error, Request};
 
         fn payload_serde_json_value(req: &Request) -> Result<::serde_json::Value, Response> {
             let value = req.payload::<::serde_json::Value>()
                 .ok_or_else(|| Response::BadRequest())?
-                .map_err(|e| {eprintln!("{e}"); Response::BadRequest()})?;
+                .map_err(|e| {log_error!("{e}"); Response::BadRequest()})?;
             Ok(value)
         }
     }

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -4,7 +4,7 @@ use std::{any::Any, pin::Pin, sync::Arc, future::Future, time::Duration, task::P
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use crate::__rt__::{TcpStream, sleep};
 use crate::ohkami::router::RadixRouter;
-use crate::{Request, Response};
+use crate::{log_error, Request, Response};
 
 
 pub(crate) struct Session {
@@ -25,11 +25,11 @@ impl Session {
     pub(crate) async fn manage(mut self) {
         fn panicking(panic: Box<dyn Any + Send>) -> Response {
             if let Some(msg) = panic.downcast_ref::<String>() {
-                eprintln!("[Panicked]: {msg}");
+                log_error!("[Panicked]: {msg}");
             } else if let Some(msg) = panic.downcast_ref::<&str>() {
-                eprintln!("[Panicked]: {msg}");
+                log_error!("[Panicked]: {msg}");
             } else {
-                eprintln!("[Panicked]");
+                log_error!("[Panicked]");
             }
             crate::Response::InternalServerError()
         }

--- a/ohkami/src/typed/status.rs
+++ b/ohkami/src/typed/status.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use serde::Serialize;
 use super::{Payload, PayloadType};
-use crate::{IntoResponse, Response, Status};
+use crate::{log_error, IntoResponse, Response, Status};
 
 
 /// `Payload + Serialize`, or `()`
@@ -21,7 +21,7 @@ const _: () = {
             let mut res = Response::of(status);
             if let Err(e) = self.inject(&mut res) {
                 return (|| {
-                    eprintln!("Failed to serialize {} payload: {e}", P::Type::CONTENT_TYPE);
+                    log_error!("Failed to serialize {} payload: {e}", P::Type::CONTENT_TYPE);
                     Response::InternalServerError()
                 })()
             }


### PR DESCRIPTION
- Change `Payload + Deserialize`'s `FromRequest::from_request`: respond with error text
- Update internal error logging to call `worker::console_error` additionally on `rt_worker`, instead of only `eprintln`