### PR TITLE
Call `crate::warning!` directly

### DIFF
--- a/ohkami/src/builtin/fang/cors.rs
+++ b/ohkami/src/builtin/fang/cors.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use crate::{header::append, warning, Fang, FangProc, IntoResponse, Method, Request, Response, Status};
+use crate::{header::append, Fang, FangProc, IntoResponse, Method, Request, Response, Status};
 
 
 /// # Builtin fang for CORS config
@@ -81,7 +81,7 @@ impl CORS {
 
     pub fn AllowCredentials(mut self) -> Self {
         if self.AllowOrigin.is_any() {
-            #[cfg(debug_assertions)] warning!("\
+            #[cfg(debug_assertions)] crate::warning!("\
                 [WRANING] \
                 'Access-Control-Allow-Origin' header \
                 must not have wildcard '*' when the request's credentials mode is 'include' \

--- a/ohkami/src/fangs/handler/into_handler.rs
+++ b/ohkami/src/fangs/handler/into_handler.rs
@@ -1,7 +1,7 @@
 use std::{future::Future, pin::Pin};
 use ohkami_lib::percent_decode_utf8;
 use super::Handler;
-use crate::{warning, Response, FromRequest, FromParam, Request, IntoResponse};
+use crate::{Response, FromRequest, FromParam, Request, IntoResponse};
 
 
 pub trait IntoHandler<T> {
@@ -17,7 +17,7 @@ pub trait IntoHandler<T> {
 ) -> Result<P, Response> {
     let param = percent_decode_utf8(param_bytes_maybe_percent_encoded)
         .map_err(|_e| {
-            #[cfg(debug_assertions)] warning!(
+            #[cfg(debug_assertions)] crate::warning!(
                 "[WARNING] Failed to decode percent encoding `{}`: {_e}",
                 param_bytes_maybe_percent_encoded.escape_ascii()
             );

--- a/ohkami/src/ohkami/build.rs
+++ b/ohkami/src/ohkami/build.rs
@@ -2,7 +2,7 @@
 
 use super::router::{TrieRouter, RouteSections};
 use crate::fangs::{Handler, IntoHandler};
-use crate::{Ohkami, warning};
+use crate::Ohkami;
 
 
 macro_rules! Handlers {
@@ -88,7 +88,7 @@ pub struct Dir {
                         .collect::<std::io::Result<Vec<_>>>()?;
 
                     if path_sections.last().unwrap().starts_with('.') {
-                        warning!("\
+                        crate::warning!("\
                             =========\n\
                             [WARNING] `Route::Dir`: found `{}` in directory `{}`, \
                             are you sure to serve this file？\n\

--- a/ohkami/src/ohkami/router/trie.rs
+++ b/ohkami/src/ohkami/router/trie.rs
@@ -2,7 +2,6 @@ use std::{borrow::Cow, sync::Arc};
 use super::{RouteSection, RouteSections};
 use super::super::build::{Handlers, ByAnother};
 use crate::fangs::{BoxedFPC, Fangs, Handler};
-use crate::warning;
 
 
 #[derive(Debug)]
@@ -208,7 +207,7 @@ impl TrieRouter {
         if let Err(e) = self.root.register_handlers(route.into_iter(), HandlerMap {
             GET, PUT, POST, PATCH, DELETE
         }) {
-            warning!("Failed to register handlers: {e}");
+            crate::warning!("Failed to register handlers: {e}");
             std::process::exit(1)
         }
     }

--- a/ohkami/src/request/from_request.rs
+++ b/ohkami/src/request/from_request.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use crate::{warning, IntoResponse, Request, Response};
+use crate::{IntoResponse, Request, Response};
 
 
 pub enum FromRequestError {
@@ -147,7 +147,7 @@ pub trait FromParam<'p>: Sized {
         type Error = FromRequestError;
         fn from_param(param: Cow<'p, str>) -> Result<Self, Self::Error> {
             #[cold] fn unexpectedly_percent_encoded() -> FromRequestError {
-                warning!("\
+                crate::warning!("\
                     \n\
                     =========\n\
                     [WARNING] \

--- a/ohkami/src/request/memory.rs
+++ b/ohkami/src/request/memory.rs
@@ -4,8 +4,6 @@ use std::{
     hash::{Hasher, BuildHasherDefault},
 };
 
-use crate::warning;
-
 
 pub struct Store(
     Option<Box<
@@ -96,7 +94,7 @@ super::FromRequest<'req> for Memory<'req, Data> {
             Some(d) => Some(Ok(d)),
             None => {
                 #[cfg(debug_assertions)] {
-                    warning!(
+                    crate::warning!(
                         "`Memory` of type `{}` was not found",
                         std::any::type_name::<Data>()
                     )

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -161,14 +161,14 @@ impl Request {
         mut self: Pin<&mut Self>,
         stream:   &mut (impl AsyncReader + Unpin),
     ) -> Result<Option<()>, crate::Response> {
-        use crate::{warning, Response};
+        use crate::Response;
 
         match stream.read(&mut *self.__buf__).await {
             Ok (0) => return Ok(None),
             Err(e) => return match e.kind() {
                 std::io::ErrorKind::ConnectionReset => Ok(None),
                 _ => Err((|| {
-                    warning!("Failed to read stream: {e}");
+                    crate::warning!("Failed to read stream: {e}");
                     Response::InternalServerError()
                 })())
             },

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use crate::{header::private::{Append, SetCookie, SetCookieBuilder}, warning};
+use crate::header::private::{Append, SetCookie, SetCookieBuilder};
 use rustc_hash::FxHashMap;
 
 
@@ -305,7 +305,9 @@ const _: () = {
                 setcookies.iter().filter_map(|raw| match SetCookie::from_raw(raw) {
                     Ok(valid) => Some(valid),
                     Err(_err) => {
-                        #[cfg(debug_assertions)] warning!("Invalid `Set-Cookie`: {_err}");
+                        #[cfg(debug_assertions)] crate::warning!(
+                            "Invalid `Set-Cookie`: {_err}"
+                        );
                         None
                     }
                 })

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -4,7 +4,7 @@ use std::{any::Any, pin::Pin, sync::Arc, future::Future, time::Duration, task::P
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use crate::__rt__::{TcpStream, sleep};
 use crate::ohkami::router::RadixRouter;
-use crate::{warning, Request, Response};
+use crate::{Request, Response};
 
 
 pub(crate) struct Session {
@@ -25,11 +25,11 @@ impl Session {
     pub(crate) async fn manage(mut self) {
         fn panicking(panic: Box<dyn Any + Send>) -> Response {
             if let Some(msg) = panic.downcast_ref::<String>() {
-                warning!("[Panicked]: {msg}");
+                crate::warning!("[Panicked]: {msg}");
             } else if let Some(msg) = panic.downcast_ref::<&str>() {
-                warning!("[Panicked]: {msg}");
+                crate::warning!("[Panicked]: {msg}");
             } else {
-                warning!("[Panicked]");
+                crate::warning!("[Panicked]");
             }
             crate::Response::InternalServerError()
         }

--- a/ohkami/src/typed/payload.rs
+++ b/ohkami/src/typed/payload.rs
@@ -1,4 +1,4 @@
-use crate::{warning, FromRequest, IntoResponse, Request, Response};
+use crate::{FromRequest, IntoResponse, Request, Response};
 use serde::{Serialize, Deserialize};
 
 
@@ -88,7 +88,7 @@ pub trait Payload: Sized {
             }
         } else {
             #[cfg(debug_assertions)] {
-                warning!("Expected `{}` payload but found {}",
+                crate::warning!("Expected `{}` payload but found {}",
                     <Self::Type>::MIME_TYPE,
                     req.headers.ContentType().map(|ct| format!("`{ct}`")).unwrap_or(String::from("nothing"))
                 )
@@ -187,7 +187,7 @@ const _: () = {
             let mut res = Response::OK();
             if let Err(e) = self.inject(&mut res) {
                 return (|| {
-                    warning!("Failed to serialize {} payload: {e}", <<Self as Payload>::Type>::MIME_TYPE);
+                    crate::warning!("Failed to serialize {} payload: {e}", <<Self as Payload>::Type>::MIME_TYPE);
                     Response::InternalServerError()
                 })()
             }

--- a/ohkami/src/typed/status.rs
+++ b/ohkami/src/typed/status.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use serde::Serialize;
 use super::{Payload, PayloadType};
-use crate::{warning, IntoResponse, Response, Status};
+use crate::{IntoResponse, Response, Status};
 
 
 /// `Payload + Serialize`, or `()`
@@ -21,7 +21,7 @@ const _: () = {
             let mut res = Response::of(status);
             if let Err(e) = self.inject(&mut res) {
                 return (|| {
-                    warning!("Failed to serialize {} payload: {e}", P::Type::CONTENT_TYPE);
+                    crate::warning!("Failed to serialize {} payload: {e}", P::Type::CONTENT_TYPE);
                     Response::InternalServerError()
                 })()
             }


### PR DESCRIPTION
omit `use crate::warning` and call `crate::warning!(〜)` directly to avoid rustc warnings