### PR TITLE
Optimized size-hexizing in sending chunked encoding

### DIFF
--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -177,6 +177,7 @@ impl Response {
                         }
                         Ok(chunk) => {
                             let mut message = Vec::with_capacity(
+                                /* capacity for a single line */
                                 "data: ".len() + chunk.len() + "\n\n".len()
                             );
                             for line in chunk.split('\n') {
@@ -186,15 +187,7 @@ impl Response {
                             }
                             message.push(b'\n');
 
-                            let size_hex = message.len()
-                                .to_be_bytes()
-                                .map(|byte| [byte>>4, byte&(8+4+2+1)]
-                                    .map(|n| match n {
-                                        0=>"0",1=>"1", 2=>"2", 3=>"3", 4=>"4", 5=>"5", 6=>"6", 7=>"7",
-                                        8=>"8",9=>"9",10=>"a",11=>"b",12=>"c",13=>"d",14=>"e",15=>"f",
-                                        _=>unreachable!()
-                                    }).concat()
-                                ).concat();
+                            let size_hex = ohkami_lib::num::hexize(message.len());
 
                             let mut chunk = Vec::from(size_hex.trim_start_matches('0'));
                             chunk.extend_from_slice(b"\r\n");

--- a/ohkami_lib/src/lib.rs
+++ b/ohkami_lib/src/lib.rs
@@ -2,6 +2,8 @@ pub mod base64;
 
 pub mod mime;
 
+pub mod num;
+
 mod time;
 pub use time::imf_fixdate;
 

--- a/ohkami_lib/src/num.rs
+++ b/ohkami_lib/src/num.rs
@@ -1,0 +1,38 @@
+#[inline]
+pub fn hexize(n: usize) -> String {
+    use std::{mem, ptr};
+
+    let mut hex = String::with_capacity(mem::size_of::<usize>() * 2);
+    unsafe {
+        for char_byte in mem::transmute::<_, [u8; mem::size_of::<usize>() * 2]>(
+            n.to_be_bytes().map(|byte| [byte>>4, byte&(8+4+2+1)])
+        ).map(|h| h + match h {
+            0..=9   => b'0'-0,
+            10..=15 => b'a'-10,
+            _ => std::hint::unreachable_unchecked()
+        }) {
+            let hex = hex.as_mut_vec(); {
+                let len = hex.len();
+                ptr::write(hex.as_mut_ptr().add(len), char_byte);
+                hex.set_len(len + 1);
+            }
+        }
+    }
+
+    hex
+}
+
+
+#[cfg(test)]
+#[test] fn test_hexize() {
+    for (n, expected) in [
+        (1,   "1"),
+        (9,   "9"),
+        (12,  "c"),
+        (16,  "10"),
+        (42,  "2a"),
+        (314, "13a"),
+    ] {
+        assert_eq!(hexize(n).trim_start_matches('0'), expected)
+    }
+}


### PR DESCRIPTION
- Implemented `ohkami_lib::num::hexize` and use it in `Content::Stream` arm of `Response::send`