### PR TITLE
Dispatch routers by method

### DIFF
--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -37,7 +37,7 @@ sha2          = { version = "0.10", default-features = false }
 
 
 [features]
-#default       = ["testing"]
+default       = ["testing"]
 
 rt_tokio      = ["dep:tokio"]
 rt_async-std  = ["dep:async-std"]
@@ -54,13 +54,13 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-default = [
-    "nightly",
-    "testing",
-    "sse",
-    #"websocket",
-    "rt_tokio",
-    #"rt_async-std",
-    #"rt_worker",
-    "DEBUG",
-]
+#default = [
+#    "nightly",
+#    "testing",
+#    "sse",
+#    #"websocket",
+#    "rt_tokio",
+#    #"rt_async-std",
+#    #"rt_worker",
+#    "DEBUG",
+#]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -37,7 +37,7 @@ sha2          = { version = "0.10", default-features = false }
 
 
 [features]
-default       = ["testing"]
+#default       = ["testing"]
 
 rt_tokio      = ["dep:tokio"]
 rt_async-std  = ["dep:async-std"]
@@ -54,13 +54,13 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-#default = [
-#    "nightly",
-#    "testing",
-#    "sse",
-#    #"websocket",
-#    "rt_tokio",
-#    #"rt_async-std",
-#    #"rt_worker",
-#    "DEBUG",
-#]
+default = [
+    "nightly",
+    "testing",
+    "sse",
+    #"websocket",
+    "rt_tokio",
+    #"rt_async-std",
+    #"rt_worker",
+    "DEBUG",
+]

--- a/ohkami/src/builtin/fang/cors.rs
+++ b/ohkami/src/builtin/fang/cors.rs
@@ -188,8 +188,7 @@ mod test {
     use super::CORS;
 
     #[crate::__rt__::test] async fn options_request() {
-        let t = Ohkami::with(
-            CORS::new("https://example.x.y.z"),
+        let t = Ohkami::with(CORS::new("https://example.x.y.z"),
             "/hello".GET(|| async {"Hello!"})
         ).test(); {
             let req = TestRequest::OPTIONS("/");
@@ -204,8 +203,7 @@ mod test {
     }
 
     #[crate::__rt__::test] async fn cors_headers() {
-        let t = Ohkami::with(
-            CORS::new("https://example.example"),
+        let t = Ohkami::with(CORS::new("https://example.example"),
             "/".GET(|| async {"Hello!"})
         ).test(); {
             let req = TestRequest::GET("/");

--- a/ohkami/src/builtin/fang/timeout.rs
+++ b/ohkami/src/builtin/fang/timeout.rs
@@ -139,7 +139,7 @@ const _: () = {
     {
         let req = TestRequest::PUT("/greet/ohkami/1");
         let res = t.oneshot(req).await;
-        assert_eq!(res.status(), Status::MethodNotAllowed);
+        assert_eq!(res.status(), Status::NotFound);
     }
     {
         let req = TestRequest::GET("/greet/ohkami/1");

--- a/ohkami/src/fangs/handler/mod.rs
+++ b/ohkami/src/fangs/handler/mod.rs
@@ -48,6 +48,7 @@ impl Handler {
     }
 }
 
+#[allow(unused)]
 impl Handler {
     pub(crate) fn default_not_found() -> Self {        
         Handler({
@@ -64,10 +65,21 @@ impl Handler {
         Handler({
             static H: std::sync::OnceLock<Handler> = std::sync::OnceLock::new();
             H.get_or_init(|| {
-                async fn not_found() -> Response {
+                async fn no_content() -> Response {
                     Response::NoContent()
                 }
-                not_found.into_handler()
+                no_content.into_handler()
+            }).0.clone()
+        })
+    }
+    pub(crate) fn default_not_implemented() -> Self {
+        Handler({
+            static H: std::sync::OnceLock<Handler> = std::sync::OnceLock::new();
+            H.get_or_init(|| {
+                async fn not_implemented() -> Response {
+                    Response::NotImplemented()
+                }
+                not_implemented.into_handler()
             }).0.clone()
         })
     }

--- a/ohkami/src/fangs/handler/mod.rs
+++ b/ohkami/src/fangs/handler/mod.rs
@@ -6,6 +6,7 @@ use crate::{Request, Response};
 use std::{pin::Pin, future::Future};
 
 
+#[derive(Clone)]
 pub struct Handler(BoxedFPC);
 
 const _: () = {
@@ -65,17 +66,6 @@ impl Handler {
             H.get_or_init(|| {
                 async fn not_found() -> Response {
                     Response::NoContent()
-                }
-                not_found.into_handler()
-            }).0.clone()
-        })
-    }
-    pub(crate) fn default_method_not_allowed() -> Self {
-        Handler({
-            static H: std::sync::OnceLock<Handler> = std::sync::OnceLock::new();
-            H.get_or_init(|| {
-                async fn not_found() -> Response {
-                    Response::MethodNotAllowed()
                 }
                 not_found.into_handler()
             }).0.clone()

--- a/ohkami/src/ohkami/_test.rs
+++ b/ohkami/src/ohkami/_test.rs
@@ -99,11 +99,11 @@ fn my_ohkami() -> Ohkami {
 
     let req = TestRequest::GET("/api/profiles/the_user/follow");
     let res = t.oneshot(req).await;
-    assert_eq!(res.status(), Status::MethodNotAllowed);
+    assert_eq!(res.status(), Status::NotFound);
 
     let req = TestRequest::POST("/api/profiles/the_user");
     let res = t.oneshot(req).await;
-    assert_eq!(res.status(), Status::MethodNotAllowed);
+    assert_eq!(res.status(), Status::NotFound);
 
     let req = TestRequest::POST("/api/profiles/the_user/follow");
     let res = t.oneshot(req).await;

--- a/ohkami/src/ohkami/_test.rs
+++ b/ohkami/src/ohkami/_test.rs
@@ -76,23 +76,45 @@ fn my_ohkami() -> Ohkami {
 #[crate::__rt__::test] async fn test_handler_registration() {
     let t = my_ohkami().test();
 
-
     /* GET /health */
 
     let req = TestRequest::GET("/health");
-    let res = t.oneshot(req).await;
-    assert_eq!(res.text(), Some("health_check"));
+    let get_res = t.oneshot(req).await;
+    assert_eq!(get_res.text(), Some("health_check"));
 
+    let req = TestRequest::HEAD("/health");
+    let head_res = t.oneshot(req).await;
+    assert_eq!(head_res.text(), None);
+    assert_eq!(
+        {let mut h = get_res.headers().filter(|(name, _)| *name != "Content-Length").collect::<Vec<_>>(); h.sort(); h},
+        {let mut h = head_res.headers().collect::<Vec<_>>(); h.sort(); h}
+    );
 
     /* GET /api/profiles/:username */
 
     let req = TestRequest::GET("/api/profiles");
-    let res = t.oneshot(req).await;
-    assert_eq!(res.status(), Status::NotFound);
+    let get_res = t.oneshot(req).await;
+    assert_eq!(get_res.status(), Status::NotFound);
+
+    let req = TestRequest::HEAD("/api/profiles");
+    let head_res = t.oneshot(req).await;
+    assert_eq!(head_res.text(), None);
+    assert_eq!(
+        {let mut h = get_res.headers().filter(|(name, _)| *name != "Content-Length").collect::<Vec<_>>(); h.sort(); h},
+        {let mut h = head_res.headers().collect::<Vec<_>>(); h.sort(); h}
+    );
 
     let req = TestRequest::GET("/api/profiles/123");
-    let res = t.oneshot(req).await;
-    assert_eq!(res.text(), Some("get_profile of user `123`"));
+    let get_res = t.oneshot(req).await;
+    assert_eq!(get_res.text(), Some("get_profile of user `123`"));
+
+    let req = TestRequest::HEAD("/api/profiles/123");
+    let head_res = t.oneshot(req).await;
+    assert_eq!(head_res.text(), None);
+    assert_eq!(
+        {let mut h = get_res.headers().filter(|(name, _)| *name != "Content-Length").collect::<Vec<_>>(); h.sort(); h},
+        {let mut h = head_res.headers().collect::<Vec<_>>(); h.sort(); h}
+    );
 
 
     /* POST,DELETE /api/profiles/:username/follow */

--- a/ohkami/src/ohkami/router/radix.rs
+++ b/ohkami/src/ohkami/router/radix.rs
@@ -64,29 +64,6 @@ pub(super) struct Node {
     }
 };
 
-// pub(super) struct ProcMap {
-//     pub(super) GET:       BoxedFPC,
-//     pub(super) PUT:       BoxedFPC,
-//     pub(super) POST:      BoxedFPC,
-//     pub(super) PATCH:     BoxedFPC,
-//     pub(super) DELETE:    BoxedFPC,
-//     pub(super) OPTIONS:   BoxedFPC,
-//     pub(super) __catch__: BoxedFPC,
-// } impl ProcMap {
-//     #[inline(always)]
-//     const fn lookup(&self, method: Method) -> &BoxedFPC {
-//         match method {
-//             Method::GET     => &self.GET,
-//             Method::PUT     => &self.PUT,
-//             Method::POST    => &self.POST,
-//             Method::PATCH   => &self.PATCH,
-//             Method::DELETE  => &self.DELETE,
-//             Method::OPTIONS => &self.OPTIONS,
-//             Method::HEAD    => &self.GET,
-//         }
-//     }
-// }
-
 pub(super) enum Pattern {
     Static(&'static [u8]),
     Param,

--- a/ohkami/src/ohkami/router/radix.rs
+++ b/ohkami/src/ohkami/router/radix.rs
@@ -1,3 +1,4 @@
+use crate::request::Path;
 use crate::{Method, Request, Response};
 use crate::fangs::{FangProcCaller, BoxedFPC, Handler};
 use ohkami_lib::Slice;
@@ -5,12 +6,21 @@ use std::fmt::Write as _;
 
 
 #[derive(Debug)]
-pub(crate) struct RadixRouter(pub(super) Node);
+pub(crate) struct RadixRouter {
+    pub(super) GET:     Node,
+    pub(super) PUT:     Node,
+    pub(super) POST:    Node,
+    pub(super) PATCH:   Node,
+    pub(super) DELETE:  Node,
+    pub(super) HEAD:    Node,
+    pub(super) OPTIONS: Node,
+}
 
 pub(super) struct Node {
-    pub(super) patterns: &'static [Pattern],
-    pub(super) proc:     ProcMap,
-    pub(super) children: &'static [Node],
+    pub(super) patterns:  &'static [Pattern],
+    pub(super) children:  &'static [Node],
+    pub(super) proc:      BoxedFPC,
+    pub(super) __catch__: BoxedFPC,
 } const _: () = {
     impl std::fmt::Debug for Node {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -54,28 +64,28 @@ pub(super) struct Node {
     }
 };
 
-pub(super) struct ProcMap {
-    pub(super) GET:       BoxedFPC,
-    pub(super) PUT:       BoxedFPC,
-    pub(super) POST:      BoxedFPC,
-    pub(super) PATCH:     BoxedFPC,
-    pub(super) DELETE:    BoxedFPC,
-    pub(super) OPTIONS:   BoxedFPC,
-    pub(super) __catch__: BoxedFPC,
-} impl ProcMap {
-    #[inline(always)]
-    const fn lookup(&self, method: Method) -> &BoxedFPC {
-        match method {
-            Method::GET     => &self.GET,
-            Method::PUT     => &self.PUT,
-            Method::POST    => &self.POST,
-            Method::PATCH   => &self.PATCH,
-            Method::DELETE  => &self.DELETE,
-            Method::OPTIONS => &self.OPTIONS,
-            Method::HEAD    => &self.GET,
-        }
-    }
-}
+// pub(super) struct ProcMap {
+//     pub(super) GET:       BoxedFPC,
+//     pub(super) PUT:       BoxedFPC,
+//     pub(super) POST:      BoxedFPC,
+//     pub(super) PATCH:     BoxedFPC,
+//     pub(super) DELETE:    BoxedFPC,
+//     pub(super) OPTIONS:   BoxedFPC,
+//     pub(super) __catch__: BoxedFPC,
+// } impl ProcMap {
+//     #[inline(always)]
+//     const fn lookup(&self, method: Method) -> &BoxedFPC {
+//         match method {
+//             Method::GET     => &self.GET,
+//             Method::PUT     => &self.PUT,
+//             Method::POST    => &self.POST,
+//             Method::PATCH   => &self.PATCH,
+//             Method::DELETE  => &self.DELETE,
+//             Method::OPTIONS => &self.OPTIONS,
+//             Method::HEAD    => &self.GET,
+//         }
+//     }
+// }
 
 pub(super) enum Pattern {
     Static(&'static [u8]),
@@ -105,29 +115,33 @@ impl RadixRouter {
         &self,
         req: &mut Request,
     ) -> Response {
-        let res = self.0.search(req).call_bite(req).await;
-        
-        match req.method {
-            Method::HEAD => res.without_content(),
-            _            => res,
-        }
+        (match req.method {
+            Method::GET     => &self.GET,
+            Method::PUT     => &self.PUT,
+            Method::POST    => &self.POST,
+            Method::PATCH   => &self.PATCH,
+            Method::DELETE  => &self.DELETE,
+            Method::HEAD    => &self.HEAD,
+            Method::OPTIONS => &self.OPTIONS,
+        }).search(&mut req.path).call_bite(req).await
     }
 }
 
 impl Node {
-    pub(super/* for test */) fn search(&self, req: &mut Request) -> &dyn FangProcCaller {
-        let method = req.method;
+    pub(super/* for test */) fn search(&self,
+        path: &mut Path
+    ) -> &dyn FangProcCaller {
         // SAFETY:
         // 1. `req` must be alive while `search`
-        // 2. `Request` DOESN'T have method that mutates `path`,
-        //    So what `path` refers to is NEVER changed by any other process
+        // 2. `Request` DOESN'T have method that mutates `bytes`,
+        //    So what `bytes` refers to is NEVER changed by any other process
         //    while `search`
-        let mut path = unsafe {req.path.normalized_bytes()};
+        let mut bytes = unsafe {path.normalized_bytes()};
 
         let mut target = self;
 
         #[cfg(feature="DEBUG")]
-        println!("[path] '{}'", path.escape_ascii());
+        println!("[path] '{}'", bytes.escape_ascii());
 
         loop {
             #[cfg(feature="DEBUG")]
@@ -137,42 +151,42 @@ impl Node {
             println!("[patterns] {:?}", target.patterns);
     
             for pattern in target.patterns {
-                if path.is_empty() || unsafe {path.get_unchecked(0)} != &b'/' {
+                if bytes.is_empty() || unsafe {bytes.get_unchecked(0)} != &b'/' {
                     // At least one `pattern` to match is remaining
-                    // but remaining `path` doesn't start with '/'
-                    return &*target.proc.__catch__
+                    // but remaining `bytes` doesn't start with '/'
+                    return &target.__catch__
                 }
 
-                path = unsafe {path.get_unchecked(1..)};
+                bytes = unsafe {bytes.get_unchecked(1..)};
                 
                 #[cfg(feature="DEBUG")]
-                println!("[path striped prefix '/'] '{}'", path.escape_ascii());
+                println!("[bytes striped prefix '/'] '{}'", bytes.escape_ascii());
         
                 match pattern {
-                    Pattern::Static(s)  => path = match path.strip_prefix(*s) {
+                    Pattern::Static(s)  => bytes = match bytes.strip_prefix(*s) {
                         Some(remaining) => remaining,
-                        None            => return &*target.proc.__catch__,
+                        None            => return &target.__catch__,
                     },
                     Pattern::Param      => {
-                        let (param, remaining) = split_next_section(path);
-                        unsafe {req.path.push_param(Slice::from_bytes(param))}
-                        path = remaining;
+                        let (param, remaining) = split_next_section(bytes);
+                        unsafe {path.push_param(Slice::from_bytes(param))}
+                        bytes = remaining;
                     },
                 }
             }
 
-            if path.is_empty() {
+            if bytes.is_empty() {
                 #[cfg(feature="DEBUG")]
                 println!("Found: {target:?}");
         
-                return  &*target.proc.lookup(method)
+                return  &target.proc
             } else {
                 #[cfg(feature="DEBUG")]
                 println!("not found, searching children: {:#?}", target.children);
         
-                target = match target.matchable_child(path) {
+                target = match target.matchable_child(bytes) {
                     Some(child) => child,
-                    None        => return &*target.proc.__catch__,
+                    None        => return &target.__catch__,
                 }
             }
         }

--- a/ohkami/src/ohkami/router/trie.rs
+++ b/ohkami/src/ohkami/router/trie.rs
@@ -327,9 +327,10 @@ impl Node {
         });
 
         super::radix::Node {
-            proc:     handlers.into_procmap_with(fangs_list),
-            patterns: Box::leak(patterns.into_iter().map(Pattern::into_radix).collect()),
-            children: Box::leak(children.into_iter().map(Node::into_radix).collect::<Box<[_]>>()),
+            patterns:  Box::leak(patterns.into_iter().map(Pattern::into_radix).collect()),
+            children:  Box::leak(children.into_iter().map(Node::into_radix).collect::<Box<[_]>>()),
+            proc:      handlers.into_procmap_with(fangs_list),
+            __catch__: /* method: HEAD -> clone GET's one but drop content, other -> come on */,
         }
     }
 }

--- a/ohkami/src/testing/mod.rs
+++ b/ohkami/src/testing/mod.rs
@@ -192,6 +192,9 @@ impl TestResponse {
             .and_then(|h| self.0.headers.get(h))
             .or_else(|| self.0.headers.get_custom(name))
     }
+    pub fn headers(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.0.headers.iter()
+    }
 
     pub fn text(&self) -> Option<&str> {
         if self.0.headers.ContentType()?.starts_with("text/plain") {


### PR DESCRIPTION
- Stop sticking to respond with `405 Method Not Allowed` and use `404 Not Found` instead in following situation :

```rust
Ohkami::new(
    "/abc".POST( 〜 )
).howl("localhost:3000").await
```
```
curl http://localhost:3000
```
- Respond with `501 Not Implemented` for OPTIONS requests to existing paths by default
- Fix HEAD handling to remain `Content-Type` header from GET response