### PR TITLE
handle HEAD request by GET tree and respond without content, Content-Length

### DIFF
--- a/ohkami/src/request/_test_parse.rs
+++ b/ohkami/src/request/_test_parse.rs
@@ -37,6 +37,20 @@ fn metadataize(input: &str) -> Box<[u8; BUF_SIZE]> {
     Box::new(buf)
 }
 
+#[test]
+fn parse_path() {
+    let mut path = Path::uninit();
+    path.init_with_request_bytes(b"/abc").unwrap();
+    assert_eq!(&*path, "/abc");
+
+    let mut path = Path::uninit();
+    path.init_with_request_bytes(b"/abc/").unwrap();
+    assert_eq!(&*path, "/abc");
+
+    let mut path = Path::uninit();
+    path.init_with_request_bytes(b"/").unwrap();
+    assert_eq!(&*path, "/");
+}
 
 #[crate::__rt__::test] async fn test_parse_request() {
     use super::{RequestHeader, RequestHeaders};

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -286,10 +286,9 @@ impl Request {
         });
         // SAFETY: Just calling for request bytes and `self.__url__` is already initialized
         unsafe {let __url__ = self.__url__.assume_init_ref();
-            let path  = Path::from_request_bytes(__url__.path().as_bytes()).unwrap();
-            let query = __url__.query().map(|str| QueryParams::new(str.as_bytes()));
-            self.path  = path;
-            self.query = query;
+            let path = Slice::from_bytes(__url__.path().as_bytes()).as_bytes();
+            self.query = __url__.query().map(|str| QueryParams::new(str.as_bytes()));
+            self.path.init_with_request_bytes(path)?;
         }
 
         r.consume("HTTP/1.1\r\n").ok_or_else(Response::HTTPVersionNotSupported)?;
@@ -337,10 +336,9 @@ impl Request {
 
         // SAFETY: Just calling for request bytes and `self.__url__` is already initialized
         unsafe {let __url__ = self.__url__.assume_init_ref();
-            let path  = Path::from_request_bytes(__url__.path().as_bytes()).unwrap();
-            let query = __url__.query().map(|str| QueryParams::new(str.as_bytes()));
-            self.path  = path;
-            self.query = query;
+            let path = Slice::from_bytes(__url__.path().as_bytes()).as_bytes();
+            self.query = __url__.query().map(|str| QueryParams::new(str.as_bytes()));
+            self.path.init_with_request_bytes(path)?;
         }
 
         self.headers.take_over(req.headers());

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -190,7 +190,7 @@ impl Request {
 
         r.next_if(|b| *b==b' ').ok_or_else(Response::BadRequest)?;
         
-        self.path = Path::from_request_bytes(r.read_while(|b| !matches!(b, b' ' | b'?')))?;
+        self.path.init_with_request_bytes(r.read_while(|b| !matches!(b, b' ' | b'?')))?;
 
         if r.consume_oneof([" ", "?"]).unwrap() == 1 {
             self.query = Some(QueryParams::new(r.read_while(|b| b != &b' ')));


### PR DESCRIPTION
- Save memory for redundant `HEAD` tree
- FIx `request::Path::as_ref` to return `"/"` when the original path was `"/"` & add test for it