### PR TITLE
`#[bindings]` : variable bindings as associated consts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 # `async-std` is available by feature "rt_async-std".
 
 [dependencies]
-ohkami = { version = "0.19", features = ["rt_tokio"] }
+ohkami = { version = "0.20", features = ["rt_tokio"] }
 tokio  = { version = "1",    features = ["full"] }
 ```
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -10,7 +10,7 @@ DEBUG = ["ohkami/DEBUG"]
 default = ["DEBUG"]
 
 [dependencies]
-ohkami             = { version = "0.19", path = "../ohkami", default-features = false, features = ["rt_tokio"] }
+ohkami             = { path = "../ohkami", default-features = false, features = ["rt_tokio"] }
 ohkami_lib         = { version = "0.2.3", path = "../ohkami_lib" }
 http               = "1.0.0"
 rustc-hash         = "1.1"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,7 +16,7 @@ members  = [
 [workspace.dependencies]
 # To assure "DEBUG" feature be off even if DEBUGing `../ohkami`,
 # explicitly set `default-features = false`
-ohkami             = { version = "0.19", path = "../ohkami", default-features = false, features = ["rt_tokio", "testing", "sse"] }
+ohkami             = { path = "../ohkami", default-features = false, features = ["rt_tokio", "testing", "sse"] }
 tokio              = { version = "1", features = ["full"] }
 sqlx               = { version = "0.7.3", features = ["runtime-tokio-native-tls", "postgres", "macros", "chrono", "uuid"] }
 tracing            = "0.1"

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ohkami"
-version       = "0.19.0"
+version       = "0.20.0"
 edition       = "2021"
 authors       = ["kanarus <kanarus786@gmail.com>"]
 description   = "Build web app in intuitive and declarative code"
@@ -19,7 +19,7 @@ features      = ["rt_tokio", "nightly", "sse"]
 
 [dependencies]
 ohkami_lib    = { version = "=0.2.4", path = "../ohkami_lib" }
-ohkami_macros = { version = "=0.7.4", path = "../ohkami_macros" }
+ohkami_macros = { version = "=0.8.0", path = "../ohkami_macros" }
 
 tokio         = { version = "1",   optional = true, features = ["net", "rt", "io-util", "sync", "time"] }
 async-std     = { version = "1",   optional = true }

--- a/ohkami_macros/Cargo.toml
+++ b/ohkami_macros/Cargo.toml
@@ -3,7 +3,7 @@ proc-macro = true
 
 [package]
 name          = "ohkami_macros"
-version       = "0.7.4"
+version       = "0.8.0"
 edition       = "2021"
 authors       = ["kanarus <kanarus786@gmail.com>"]
 description   = "Proc macros for Ohkami - intuitive and declarative web framework"

--- a/ohkami_macros/src/worker.rs
+++ b/ohkami_macros/src/worker.rs
@@ -215,7 +215,7 @@ pub fn bindings(env: TokenStream, bindings_struct: TokenStream) -> Result<TokenS
         let methods = bindings.iter()
             .filter_map(|(name, binding)| match binding {
                 Binding::Variable(var) => Some(quote! {
-                    #vis const fn #name() -> &'static str { #var }
+                    #vis const #name: &'static str = #var;
                 }),
                 _ => None
             });


### PR DESCRIPTION
Before

```toml
[vars]
VAR = "value"
```
```rust
#[bindings]
struct Bindings;
```

had method `Bindings::VAR() -> &'static str`, but it's more natural to have const `Bindings::VAR: &'static str`

---

This is a breaking change and bumps major version